### PR TITLE
updated circleci config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,9 +15,9 @@ jobs:
       - slack/notify:
           color: "#42e2f4"
           mentions: "channel"
-          message: new moodqueue build
+          message: "Build triggered by ${CIRCLE_USERNAME} on branch ${CIRCLE_BRANCH}"
       - slack/status:
-          fail_only: true
+          fail_only: false
           mentions: "channel"
 workflows:
   build-and-notify:


### PR DESCRIPTION
in the circleci config fail_only was set to true so we would only get circleci status notifications if it failed, updated it so we get build notifications if it passes too, also updated notification to include username & branch name