### PR TITLE
frontend experiments #2 - fun results

### DIFF
--- a/common/Helpers.ts
+++ b/common/Helpers.ts
@@ -47,12 +47,12 @@ export const getTrackSourceFromFormSelection = (formSelection: FormSelection): T
     return result
 }
 
-export const getShortenedTrackName = (trackName: string) => {
-    if (trackName.length <= 14) {
-        return trackName
+export const getShortenedName = (name: string, track: boolean) => {
+    if (name.length <= (track ? 10 : 14)) {
+        return name
     } else {
         let temp: string = ""
-        temp = trackName.substring(0, 11)
+        temp = name.substring(0, track ? 6 : 10)
         temp += "..."
         return temp
     }

--- a/components/form/form.tsx
+++ b/components/form/form.tsx
@@ -27,12 +27,7 @@ export const Form: FunctionComponent<FormProps> = (props) => {
 
     return (
         <Box justify="between" align="center" flex fill>
-            <Heading
-                id="queue-title"
-                textAlign="center"
-                margin="none"
-                size={size !== "small" ? "medium" : "small"}
-            >
+            <Heading id="queue-title" textAlign="center" margin="none" size="small">
                 new queue
             </Heading>
             <Box fill justify="evenly" align="center">

--- a/components/form/souce/source.tsx
+++ b/components/form/souce/source.tsx
@@ -42,7 +42,13 @@ export const SourceSelection: FunctionComponent<SourceSelectionProps> = (props) 
     }
 
     return (
-        <Box direction="row" align="start" fill="horizontal" justify="evenly">
+        <Box
+            direction="row"
+            align="start"
+            fill="horizontal"
+            justify={size !== "small" ? "center" : "evenly"}
+            gap={size !== "small" ? "xlarge" : undefined}
+        >
             <Text textAlign="center" size={size !== "small" ? "medium" : "small"}>
                 choose from your:
             </Text>

--- a/components/home/avatar/avatar.spec.tsx
+++ b/components/home/avatar/avatar.spec.tsx
@@ -1,0 +1,46 @@
+import React from "react"
+import { expect } from "chai"
+import { render, shallow } from "enzyme"
+import { UserAvatar } from "./"
+import { UserInfo } from "../../../types/UserInfo"
+
+const testUser: UserInfo = {
+    name: "test",
+    id: "test123",
+    email: "test123@gmail.com",
+    profileUrl: "spotify.com",
+    profileImages: [
+        {
+            url:
+                // click the url k8, follow your destiny
+                "https://i.pinimg.com/originals/1d/1b/0f/1d1b0f072bb652298e747dd02e8809fc.jpg",
+        },
+    ],
+}
+
+describe("<UserAvatar />", () => {
+    it("renders without crashing", () => {
+        shallow(<UserAvatar size={"large"} user={testUser} handleAvatarClick={jest.fn} />)
+    })
+
+    it("renders avatar with profile image", () => {
+        const wrapper = render(
+            <UserAvatar size={"large"} user={testUser} handleAvatarClick={jest.fn} />
+        )
+        expect(wrapper.find("#avatar-profile-image").length).to.be.eql(1)
+    })
+
+    it("renders default avatar if no profile image is present", () => {
+        const testUserNoProfileUrl: UserInfo = {
+            name: "test",
+            id: "test123",
+            email: "test123@gmail.com",
+            profileUrl: "spotify.com",
+            profileImages: [],
+        }
+        const wrapper = render(
+            <UserAvatar size={"large"} user={testUserNoProfileUrl} handleAvatarClick={jest.fn} />
+        )
+        expect(wrapper.find("#avatar-default").length).to.be.eql(1)
+    })
+})

--- a/components/home/avatar/avatar.tsx
+++ b/components/home/avatar/avatar.tsx
@@ -1,0 +1,53 @@
+import { Avatar, Box, Heading } from "grommet"
+import { User } from "grommet-icons"
+import React, { FunctionComponent } from "react"
+import { motion } from "framer-motion"
+import { UserInfo } from "../../../types/UserInfo"
+
+interface UserAvatarProps {
+    user: UserInfo
+    size: string
+    handleAvatarClick(): void
+}
+
+export const UserAvatar: FunctionComponent<UserAvatarProps> = (props) => {
+    const { user, size, handleAvatarClick } = props
+    const name = user.name ? user.name.toLowerCase() : "stranger"
+    return (
+        <motion.div whileHover={{ scale: 1.1 }} whileTap={{ scale: 0.9 }}>
+            <Box
+                direction="row"
+                align="center"
+                gap="small"
+                onClick={handleAvatarClick}
+                focusIndicator={false}
+                style={{ outline: "none" }}
+            >
+                {size !== "small" && (
+                    <Heading textAlign="center" margin="none" id="username-txt" size="small">
+                        {name}
+                    </Heading>
+                )}
+                {user.profileImages[0] ? (
+                    <Avatar
+                        id="avatar-profile-image"
+                        src={user.profileImages[0].url}
+                        size={size !== "small" ? "large" : "medium"}
+                        border={{ size: "small", side: "all", color: "accent-1" }}
+                        title="click to open your spotify profile"
+                    />
+                ) : (
+                    <Avatar
+                        id="avatar-default"
+                        background="accent-2"
+                        border={{ size: "small", side: "all", color: "accent-1" }}
+                        size={size !== "small" ? "large" : "medium"}
+                        title="click to open your spotify profile"
+                    >
+                        <User color="accent-1" size={size !== "small" ? "large" : "medium"} />
+                    </Avatar>
+                )}
+            </Box>
+        </motion.div>
+    )
+}

--- a/components/home/avatar/avatar.tsx
+++ b/components/home/avatar/avatar.tsx
@@ -34,7 +34,6 @@ export const UserAvatar: FunctionComponent<UserAvatarProps> = (props) => {
                         src={user.profileImages[0].url}
                         size={size !== "small" ? "large" : "medium"}
                         border={{ size: "small", side: "all", color: "accent-1" }}
-                        title="click to open your spotify profile"
                     />
                 ) : (
                     <Avatar
@@ -42,7 +41,6 @@ export const UserAvatar: FunctionComponent<UserAvatarProps> = (props) => {
                         background="accent-2"
                         border={{ size: "small", side: "all", color: "accent-1" }}
                         size={size !== "small" ? "large" : "medium"}
-                        title="click to open your spotify profile"
                     >
                         <User color="accent-1" size={size !== "small" ? "large" : "medium"} />
                     </Avatar>

--- a/components/home/avatar/index.ts
+++ b/components/home/avatar/index.ts
@@ -1,0 +1,1 @@
+export * from "./avatar"

--- a/components/home/home.spec.tsx
+++ b/components/home/home.spec.tsx
@@ -47,22 +47,4 @@ describe("<Home/>", () => {
         expect(wrapper.find("#happy-emoji-hdr")).to.be.length(1)
         expect(wrapper.find("#sad-emoji-hdr")).to.be.length(1)
     })
-
-    it("renders avatar with profile image", () => {
-        const wrapper = render(<Home user={testUser} size={"large"} />)
-        expect(wrapper.find("#avatar-profile-image").length).to.be.eql(1)
-    })
-
-    it("renders default avatar if no profile image is present", () => {
-        const userWithNoImage: UserInfo = {
-            name: "test",
-            id: "test123",
-            email: "test123@gmail.com",
-            profileUrl: "spotify.com",
-            profileImages: [],
-        }
-
-        const wrapper = render(<Home user={userWithNoImage} size={"large"} />)
-        expect(wrapper.find("#avatar-default").length).to.be.eql(1)
-    })
 })

--- a/components/home/home.spec.tsx
+++ b/components/home/home.spec.tsx
@@ -65,9 +65,4 @@ describe("<Home/>", () => {
         const wrapper = render(<Home user={userWithNoImage} size={"large"} />)
         expect(wrapper.find("#avatar-default").length).to.be.eql(1)
     })
-
-    it("renders avatar with small screen", () => {
-        const wrapper = render(<Home user={testUser} size={"small"} />)
-        expect(wrapper.find("#avatar-profile-image-small").length).to.be.eql(1)
-    })
 })

--- a/components/home/home.tsx
+++ b/components/home/home.tsx
@@ -70,7 +70,7 @@ export const Home: FunctionComponent<HomeProps> = (props) => {
                         dqueue
                     </Heading>
                     <Description
-                        textAlign={size !== "small" ? "start" : "center"}
+                        textAlign="start"
                         size={size !== "small" ? "medium" : "small"}
                         text="let your mood inspire you"
                     />

--- a/components/home/home.tsx
+++ b/components/home/home.tsx
@@ -38,73 +38,89 @@ export const Home: FunctionComponent<HomeProps> = (props) => {
             initial="hidden"
             animate="visible"
         >
-            <Box fill justify="between" overflow={{ horizontal: "hidden" }}>
-                <Header
-                    justify={size !== "small" ? "evenly" : "center"}
-                    direction={size !== "small" ? "row" : "column"}
-                >
+            <Box fill justify="between" overflow={{ horizontal: "hidden" }} pad="xsmall">
+                <Header justify="evenly" direction="row">
                     <Box border="between" gap="small">
                         <Heading
                             id="app-name-txt"
                             textAlign={size !== "small" ? "start" : "center"}
-                            size={size !== "small" ? "large" : "medium"}
+                            size="medium"
                             margin="none"
                         >
                             m
                             <Happy
-                                width={size !== "small" ? "48px" : "24px"}
-                                height={size !== "small" ? "48px" : "24px"}
+                                onClick={() =>
+                                    window.open("https://www.youtube.com/watch?v=cI0wUoCLnLk")
+                                }
+                                style={{ cursor: "pointer" }}
+                                width={size !== "small" ? "36px" : "24px"}
+                                height={size !== "small" ? "36px" : "24px"}
                                 id="happy-emoji-hdr"
                             />
                             <Sad
-                                width={size !== "small" ? "48px" : "24px"}
-                                height={size !== "small" ? "48px" : "24px"}
+                                onClick={() =>
+                                    window.open("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+                                }
+                                style={{ cursor: "pointer" }}
+                                width={size !== "small" ? "36px" : "24px"}
+                                height={size !== "small" ? "36px" : "24px"}
                                 id="sad-emoji-hdr"
                             />
                             dqueue
                         </Heading>
                         <Text
-                            weight={size !== "small" ? "bold" : "normal"}
                             textAlign={size !== "small" ? "start" : "center"}
-                            size={size}
+                            size={size !== "small" ? "medium" : "small"}
                         >
                             let your mood inspire you
                         </Text>
                     </Box>
-                    {size !== "small" && (
-                        <motion.div whileHover={{ scale: 1.1 }} whileTap={{ scale: 0.9 }}>
-                            <Box direction="row" align="center" gap="small">
-                                <Heading textAlign="center" margin="none" id="username-txt">
+
+                    <motion.div whileHover={{ scale: 1.1 }} whileTap={{ scale: 0.9 }}>
+                        <Box direction="row" align="center" gap="small">
+                            {size !== "small" && (
+                                <Heading
+                                    textAlign="center"
+                                    margin="none"
+                                    id="username-txt"
+                                    size="small"
+                                >
                                     {name}
                                 </Heading>
-                                {props.user.profileImages[0] ? (
-                                    <Avatar
-                                        id="avatar-profile-image"
-                                        src={props.user.profileImages[0].url}
-                                        size="xlarge"
-                                        border={{ size: "small", side: "all", color: "accent-1" }}
-                                        onClick={() => window.open(props.user.profileUrl, "_blank")}
-                                        title="click to open your spotify profile"
+                            )}
+                            {props.user.profileImages[0] ? (
+                                <Avatar
+                                    id="avatar-profile-image"
+                                    src={props.user.profileImages[0].url}
+                                    size={size !== "small" ? "large" : "medium"}
+                                    border={{ size: "small", side: "all", color: "accent-1" }}
+                                    onClick={() => window.open(props.user.profileUrl, "_blank")}
+                                    title="click to open your spotify profile"
+                                />
+                            ) : (
+                                <Avatar
+                                    id="avatar-default"
+                                    background="accent-2"
+                                    border={{ size: "small", side: "all", color: "accent-1" }}
+                                    size={size !== "small" ? "large" : "medium"}
+                                    onClick={() => window.open(props.user.profileUrl, "_blank")}
+                                    title="click to open your spotify profile"
+                                >
+                                    <User
+                                        color="accent-1"
+                                        size={size !== "small" ? "large" : "medium"}
                                     />
-                                ) : (
-                                    <Avatar
-                                        id="avatar-default"
-                                        background="accent-2"
-                                        border={{ size: "small", side: "all", color: "accent-1" }}
-                                        size="large"
-                                        onClick={() => window.open(props.user.profileUrl, "_blank")}
-                                        title="click to open your spotify profile"
-                                    >
-                                        <User color="accent-1" size="large" />
-                                    </Avatar>
-                                )}
-                            </Box>
-                        </motion.div>
-                    )}
+                                </Avatar>
+                            )}
+                        </Box>
+                    </motion.div>
                 </Header>
                 <Box
                     align="center"
-                    margin="small"
+                    margin={{
+                        horizontal: "small",
+                        vertical: size !== "small" ? "xsmall" : "none",
+                    }}
                     fill="vertical"
                     flex
                     justify="center"
@@ -117,7 +133,7 @@ export const Home: FunctionComponent<HomeProps> = (props) => {
                         align="center"
                         border={{
                             side: "all",
-                            size: "xlarge",
+                            size: "large",
                             style: "outset",
                             color: "accent-1",
                         }}
@@ -126,6 +142,7 @@ export const Home: FunctionComponent<HomeProps> = (props) => {
                         margin={size === "small" ? "small" : undefined}
                         pad={{
                             horizontal: size !== "small" ? "medium" : "small",
+                            vertical: "small",
                         }}
                     >
                         <motion.div
@@ -169,34 +186,6 @@ export const Home: FunctionComponent<HomeProps> = (props) => {
                         </motion.div>
                     </Box>
                 </Box>
-                {size === "small" && (
-                    <Box align="center">
-                        {props.user.profileImages[0] ? (
-                            <Avatar
-                                id="avatar-profile-image-small"
-                                src={props.user.profileImages[0].url}
-                                size={size !== "small" ? "xlarge" : "large"}
-                                border={{ size: "small", side: "all", color: "accent-1" }}
-                                onClick={() => window.open(props.user.profileUrl, "_blank")}
-                                title="click to open your spotify profile"
-                            />
-                        ) : (
-                            <Avatar
-                                id="avatar-default-small"
-                                background="accent-2"
-                                border={{ size: "small", side: "all", color: "accent-1" }}
-                                size={size !== "small" ? "large" : "medium"}
-                                onClick={() => window.open(props.user.profileUrl, "_blank")}
-                                title="click to open your spotify profile"
-                            >
-                                <User
-                                    color="accent-1"
-                                    size={size !== "small" ? "large" : "medium"}
-                                />
-                            </Avatar>
-                        )}
-                    </Box>
-                )}
             </Box>
         </motion.div>
     )

--- a/components/home/home.tsx
+++ b/components/home/home.tsx
@@ -1,6 +1,5 @@
-import { Avatar, Box, Header, Heading, Text } from "grommet"
-import { User } from "grommet-icons"
-import React, { FunctionComponent, useState } from "react"
+import { Box, Header, Heading, Text } from "grommet"
+import React, { FunctionComponent, useEffect, useState } from "react"
 import { BounceLoader } from "react-spinners"
 import { getTrackSourceFromFormSelection } from "../../common/Helpers"
 import { useSpotify } from "../../common/hooks/useSpotify"
@@ -14,6 +13,8 @@ import { motion } from "framer-motion"
 import { baseContainer, baseItemBottom } from "../animations/motion"
 import { Mood as Happy } from "@styled-icons/material-twotone/Mood"
 import { MoodBad as Sad } from "@styled-icons/material-twotone/MoodBad"
+import { UserAvatar } from "./avatar"
+import { Settings } from "./settings"
 
 interface HomeProps {
     user: UserInfo
@@ -22,13 +23,19 @@ interface HomeProps {
 
 export const Home: FunctionComponent<HomeProps> = (props) => {
     const { user, size } = props
-    const name = user.name ? user.name.toLowerCase() : "stranger"
     const [showResults, setShowResults] = useState(false)
     const [mood, setMood] = useState<Mood>(-1)
     const [source, setSource] = useState<FormSelection>(defaultFormSelection)
     const [tracks, setTracks] = useState<Track[]>()
     const [loading, setLoading] = useState(false)
+    const [resultsLayout, setResultsLayout] = useState("")
+    const [showLayer, setShowLayer] = useState(false)
     const { getQueue } = useSpotify()
+
+    useEffect(() => {
+        const resultsLayout = localStorage.getItem("resultsLayout") || "fun"
+        setResultsLayout(resultsLayout)
+    }, [])
 
     return (
         <motion.div
@@ -75,45 +82,11 @@ export const Home: FunctionComponent<HomeProps> = (props) => {
                             let your mood inspire you
                         </Text>
                     </Box>
-
-                    <motion.div whileHover={{ scale: 1.1 }} whileTap={{ scale: 0.9 }}>
-                        <Box direction="row" align="center" gap="small">
-                            {size !== "small" && (
-                                <Heading
-                                    textAlign="center"
-                                    margin="none"
-                                    id="username-txt"
-                                    size="small"
-                                >
-                                    {name}
-                                </Heading>
-                            )}
-                            {props.user.profileImages[0] ? (
-                                <Avatar
-                                    id="avatar-profile-image"
-                                    src={props.user.profileImages[0].url}
-                                    size={size !== "small" ? "large" : "medium"}
-                                    border={{ size: "small", side: "all", color: "accent-1" }}
-                                    onClick={() => window.open(props.user.profileUrl, "_blank")}
-                                    title="click to open your spotify profile"
-                                />
-                            ) : (
-                                <Avatar
-                                    id="avatar-default"
-                                    background="accent-2"
-                                    border={{ size: "small", side: "all", color: "accent-1" }}
-                                    size={size !== "small" ? "large" : "medium"}
-                                    onClick={() => window.open(props.user.profileUrl, "_blank")}
-                                    title="click to open your spotify profile"
-                                >
-                                    <User
-                                        color="accent-1"
-                                        size={size !== "small" ? "large" : "medium"}
-                                    />
-                                </Avatar>
-                            )}
-                        </Box>
-                    </motion.div>
+                    <UserAvatar
+                        user={user}
+                        size={size}
+                        handleAvatarClick={() => setShowLayer(true)}
+                    />
                 </Header>
                 <Box
                     align="center"
@@ -165,6 +138,7 @@ export const Home: FunctionComponent<HomeProps> = (props) => {
                                     size={size}
                                     mood={mood}
                                     source={source}
+                                    layout={resultsLayout}
                                     resetForm={() => setShowResults(false)}
                                 />
                             ) : (
@@ -186,6 +160,18 @@ export const Home: FunctionComponent<HomeProps> = (props) => {
                         </motion.div>
                     </Box>
                 </Box>
+                {showLayer && (
+                    <Settings
+                        profileUrl={user.profileUrl}
+                        size={size}
+                        resultsLayout={resultsLayout}
+                        handleResultsLayoutChange={(checked) => {
+                            localStorage.setItem("resultsLayout", checked ? "fun" : "normal")
+                            setResultsLayout(checked ? "fun" : "normal")
+                        }}
+                        close={() => setShowLayer(false)}
+                    />
+                )}
             </Box>
         </motion.div>
     )

--- a/components/home/settings/index.ts
+++ b/components/home/settings/index.ts
@@ -1,0 +1,1 @@
+export * from "./settings"

--- a/components/home/settings/settings.spec.tsx
+++ b/components/home/settings/settings.spec.tsx
@@ -1,0 +1,104 @@
+import React from "react"
+import { render, shallow } from "enzyme"
+import { Settings } from "./"
+import { expect } from "chai"
+
+describe("<Settings/>", () => {
+    it("renders without crashing", () => {
+        shallow(
+            <Settings
+                size={"large"}
+                profileUrl={""}
+                resultsLayout={"fun"}
+                handleResultsLayoutChange={jest.fn}
+                close={jest.fn}
+            />
+        )
+    })
+
+    it("renders title", () => {
+        const wrapper = shallow(
+            <Settings
+                size={"large"}
+                profileUrl={""}
+                resultsLayout={"fun"}
+                handleResultsLayoutChange={jest.fn}
+                close={jest.fn}
+            />
+        )
+
+        expect(wrapper.find("#header-txt").text()).to.contain("settings")
+    })
+
+    it("renders an anchor for user to open up profile in spotify", () => {
+        const wrapper = shallow(
+            <Settings
+                size={"large"}
+                profileUrl={"https://open.spotify.com/user/meuqrc1yavi4xl1v5ppz4rjs7"}
+                resultsLayout={"fun"}
+                handleResultsLayoutChange={jest.fn}
+                close={jest.fn}
+            />
+        )
+
+        expect(wrapper.find("#spotify-profile-anchor").props().href).contains(
+            "https://open.spotify.com/user/"
+        )
+    })
+
+    it("renders theme selector", () => {
+        const wrapper = shallow(
+            <Settings
+                size={"large"}
+                profileUrl={""}
+                resultsLayout={"fun"}
+                handleResultsLayoutChange={jest.fn}
+                close={jest.fn}
+            />
+        )
+
+        expect(wrapper.find("#theme-picker")).to.be.length(1)
+    })
+
+    it("renders results layout toggle switch", () => {
+        const wrapper = shallow(
+            <Settings
+                size={"large"}
+                profileUrl={""}
+                resultsLayout={"fun"}
+                handleResultsLayoutChange={jest.fn}
+                close={jest.fn}
+            />
+        )
+
+        expect(wrapper.find("#results-layout")).to.be.length(1)
+    })
+
+    it("renders a checked toggle when results layout is equal to fun", () => {
+        const wrapper = shallow(
+            <Settings
+                size={"large"}
+                profileUrl={""}
+                resultsLayout={"fun"}
+                handleResultsLayoutChange={jest.fn}
+                close={jest.fn}
+            />
+        )
+
+        expect(wrapper.find("#results-layout").prop("checked")).to.equal(true)
+    })
+
+    it("does not render a checked toggle when results layout is not equal to fun", () => {
+        const wrapper = shallow(
+            <Settings
+                size={"large"}
+                profileUrl={""}
+                resultsLayout={"normal"}
+                handleResultsLayoutChange={jest.fn}
+                close={jest.fn}
+            />
+        )
+
+        expect(wrapper.find("#results-layout").prop("checked")).to.equal(false)
+    })
+})

--- a/components/home/settings/settings.spec.tsx
+++ b/components/home/settings/settings.spec.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { render, shallow } from "enzyme"
+import { mount, render, shallow } from "enzyme"
 import { Settings } from "./"
 import { expect } from "chai"
 
@@ -17,7 +17,7 @@ describe("<Settings/>", () => {
     })
 
     it("renders title", () => {
-        const wrapper = shallow(
+        const wrapper = mount(
             <Settings
                 size={"large"}
                 profileUrl={""}
@@ -27,7 +27,7 @@ describe("<Settings/>", () => {
             />
         )
 
-        expect(wrapper.find("#header-txt").text()).to.contain("settings")
+        expect(wrapper.find("#header-txt").at(0).text()).to.contain("settings")
     })
 
     it("renders an anchor for user to open up profile in spotify", () => {
@@ -100,5 +100,33 @@ describe("<Settings/>", () => {
         )
 
         expect(wrapper.find("#results-layout").prop("checked")).to.equal(false)
+    })
+
+    it("renders a happy face when results layout is equal to fun", () => {
+        const wrapper = mount(
+            <Settings
+                size={"large"}
+                profileUrl={""}
+                resultsLayout={"fun"}
+                handleResultsLayoutChange={jest.fn}
+                close={jest.fn}
+            />
+        )
+
+        expect(wrapper.find("#fun-results-emoji").at(0)).to.be.length(1)
+    })
+
+    it("renders a sad face when results layout is not equal to fun", () => {
+        const wrapper = mount(
+            <Settings
+                size={"large"}
+                profileUrl={""}
+                resultsLayout={"normal"}
+                handleResultsLayoutChange={jest.fn}
+                close={jest.fn}
+            />
+        )
+
+        expect(wrapper.find("#normal-results-emoji").at(0)).to.be.length(1)
     })
 })

--- a/components/home/settings/settings.tsx
+++ b/components/home/settings/settings.tsx
@@ -87,11 +87,13 @@ export const Settings: FunctionComponent<SettingsProps> = (props) => {
                         />
                         {resultsLayout === "fun" ? (
                             <HappyHeartEyes
+                                id="fun-results-emoji"
                                 width={size !== "small" ? "48px" : "24px"}
                                 height={size !== "small" ? "48px" : "24px"}
                             />
                         ) : (
                             <Sad
+                                id="normal-results-emoji"
                                 width={size !== "small" ? "48px" : "24px"}
                                 height={size !== "small" ? "48px" : "24px"}
                             />

--- a/components/home/settings/settings.tsx
+++ b/components/home/settings/settings.tsx
@@ -1,0 +1,84 @@
+import { motion } from "framer-motion"
+import { Layer, Box, Heading, Anchor, Select, CheckBox } from "grommet"
+import { Spotify } from "grommet-icons"
+import React, { FunctionComponent } from "react"
+
+interface SettingsProps {
+    profileUrl: string
+    resultsLayout: string
+    size: string
+    handleResultsLayoutChange(checked: boolean): void
+    close(): void
+}
+
+export const Settings: FunctionComponent<SettingsProps> = (props) => {
+    const { profileUrl, resultsLayout, size, close, handleResultsLayoutChange } = props
+    return (
+        <Layer
+            responsive={false}
+            margin={size !== "small" ? "small" : "xsmall"}
+            position={size !== "small" ? "right" : "bottom"}
+            onClickOutside={close}
+            style={{
+                background: "transparent",
+                borderRadius: 30,
+                height: size !== "small" ? "100%" : undefined,
+                width: size === "small" ? "100%" : undefined,
+            }}
+        >
+            <Box
+                border={{ color: "neutral-4" }}
+                fill={size !== "small"}
+                flex
+                round={size === "small" ? { corner: "top" } : true}
+                align="center"
+                pad={size !== "small" ? "medium" : "large"}
+                background={{ color: "#1F2730" }}
+                style={{
+                    background: "linear-gradient(0deg, rgba(31,39,48,1) 0%, rgba(52,73,94,1) 100%)",
+                }}
+                gap={size !== "small" ? "medium" : "large"}
+            >
+                <Heading textAlign="center" id="header-txt">
+                    settings
+                </Heading>
+                <motion.div whileHover={{ scale: 1.1 }} whileTap={{ scale: 0.9 }}>
+                    <Anchor
+                        id="spotify-profile-anchor"
+                        alignSelf="center"
+                        href={profileUrl}
+                        target="blank"
+                        label={`Open profile in Spotify`}
+                        icon={<Spotify />}
+                    />
+                </motion.div>
+                <motion.div whileHover={{ scale: 1.1 }} whileTap={{ scale: 0.9 }}>
+                    <Box
+                        round="large"
+                        pad="xsmall"
+                        border={{ color: "accent-1", size: "small" }}
+                        background="#34495E"
+                    >
+                        <Select
+                            id="theme-picker"
+                            disabled
+                            focusIndicator={false}
+                            plain
+                            options={["warm + cozy", "gaegu", "cold + uncomfortable"]}
+                            placeholder="select a theme"
+                        />
+                    </Box>
+                </motion.div>
+                <motion.div whileHover={{ scale: 1.1 }} whileTap={{ scale: 0.9 }}>
+                    <CheckBox
+                        id="results-layout"
+                        toggle
+                        label="fun results"
+                        checked={resultsLayout === "fun" ? true : false}
+                        onChange={(event) => handleResultsLayoutChange(event.target.checked)}
+                    />
+                </motion.div>
+            </Box>
+        </Layer>
+    )
+}

--- a/components/home/settings/settings.tsx
+++ b/components/home/settings/settings.tsx
@@ -4,6 +4,7 @@ import { Spotify } from "grommet-icons"
 import { HappyHeartEyes } from "@styled-icons/boxicons-solid/HappyHeartEyes"
 import { Sad } from "@styled-icons/boxicons-solid/Sad"
 import React, { FunctionComponent } from "react"
+import { Description } from "../../../ui/description/Description"
 
 interface SettingsProps {
     profileUrl: string
@@ -47,9 +48,7 @@ export const Settings: FunctionComponent<SettingsProps> = (props) => {
                 }}
                 gap="large"
             >
-                <Heading textAlign="center" id="header-txt">
-                    settings
-                </Heading>
+                <Description header text="settings" textAlign="center" id="header-txt" />
                 <motion.div whileHover={{ scale: 1.1 }} whileTap={{ scale: 0.9 }}>
                     <Anchor
                         id="spotify-profile-anchor"

--- a/components/home/settings/settings.tsx
+++ b/components/home/settings/settings.tsx
@@ -1,6 +1,8 @@
 import { motion } from "framer-motion"
 import { Layer, Box, Heading, Anchor, Select, CheckBox } from "grommet"
 import { Spotify } from "grommet-icons"
+import { HappyHeartEyes } from "@styled-icons/boxicons-solid/HappyHeartEyes"
+import { Sad } from "@styled-icons/boxicons-solid/Sad"
 import React, { FunctionComponent } from "react"
 
 interface SettingsProps {
@@ -27,7 +29,10 @@ export const Settings: FunctionComponent<SettingsProps> = (props) => {
             }}
         >
             <Box
-                border={{ color: "neutral-4" }}
+                border={{
+                    color: "accent-3",
+                    size: size !== "small" ? "xsmall" : "small",
+                }}
                 fill={size !== "small"}
                 flex
                 round={size === "small" ? { corner: "top" } : true}
@@ -35,9 +40,12 @@ export const Settings: FunctionComponent<SettingsProps> = (props) => {
                 pad={size !== "small" ? "medium" : "large"}
                 background={{ color: "#1F2730" }}
                 style={{
-                    background: "linear-gradient(0deg, rgba(31,39,48,1) 0%, rgba(52,73,94,1) 100%)",
+                    background:
+                        size !== "small"
+                            ? "linear-gradient(0deg, #efd5ff 0%, #515ada 75%)"
+                            : "linear-gradient(200deg, #efd5ff 0%, #515ada 65%)",
                 }}
-                gap={size !== "small" ? "medium" : "large"}
+                gap="large"
             >
                 <Heading textAlign="center" id="header-txt">
                     settings
@@ -49,7 +57,7 @@ export const Settings: FunctionComponent<SettingsProps> = (props) => {
                         href={profileUrl}
                         target="blank"
                         label={`Open profile in Spotify`}
-                        icon={<Spotify />}
+                        icon={<Spotify size="large" />}
                     />
                 </motion.div>
                 <motion.div whileHover={{ scale: 1.1 }} whileTap={{ scale: 0.9 }}>
@@ -57,7 +65,7 @@ export const Settings: FunctionComponent<SettingsProps> = (props) => {
                         round="large"
                         pad="xsmall"
                         border={{ color: "accent-1", size: "small" }}
-                        background="#34495E"
+                        background={{ color: "#34495E", opacity: 0.6 }}
                     >
                         <Select
                             id="theme-picker"
@@ -70,13 +78,26 @@ export const Settings: FunctionComponent<SettingsProps> = (props) => {
                     </Box>
                 </motion.div>
                 <motion.div whileHover={{ scale: 1.1 }} whileTap={{ scale: 0.9 }}>
-                    <CheckBox
-                        id="results-layout"
-                        toggle
-                        label="fun results"
-                        checked={resultsLayout === "fun" ? true : false}
-                        onChange={(event) => handleResultsLayoutChange(event.target.checked)}
-                    />
+                    <Box align="center" direction="row" gap="small">
+                        <CheckBox
+                            id="results-layout"
+                            toggle
+                            label="fun results"
+                            checked={resultsLayout === "fun" ? true : false}
+                            onChange={(event) => handleResultsLayoutChange(event.target.checked)}
+                        />
+                        {resultsLayout === "fun" ? (
+                            <HappyHeartEyes
+                                width={size !== "small" ? "48px" : "24px"}
+                                height={size !== "small" ? "48px" : "24px"}
+                            />
+                        ) : (
+                            <Sad
+                                width={size !== "small" ? "48px" : "24px"}
+                                height={size !== "small" ? "48px" : "24px"}
+                            />
+                        )}
+                    </Box>
                 </motion.div>
             </Box>
         </Layer>

--- a/components/login/login.tsx
+++ b/components/login/login.tsx
@@ -19,7 +19,7 @@ export const Login: React.FunctionComponent<LoginProps> = (props) => {
     return (
         <LoginBackground>
             <Box align="center" margin={size === "small" ? "small" : undefined}>
-                <motion.div className="item" variants={baseItemTop} style={{ textAlign: "center" }}>
+                <motion.div variants={baseItemTop} style={{ textAlign: "center" }}>
                     <Heading
                         id="login-title-txt"
                         margin={{ top: "none" }}
@@ -58,8 +58,10 @@ export const Login: React.FunctionComponent<LoginProps> = (props) => {
             <motion.div variants={baseItemTop}>
                 <Button
                     id="login-btn"
-                    text="Login"
-                    icon={<Spotify color={"#666666"} />}
+                    text={size !== "small" ? "Login to Spotify" : "login"}
+                    icon={
+                        <Spotify color={"#555555"} size={size !== "small" ? "large" : "medium"} />
+                    }
                     onClick={() => openSpotifyAccountLogin(redirect, size)}
                 />
             </motion.div>

--- a/components/login/login.tsx
+++ b/components/login/login.tsx
@@ -14,7 +14,7 @@ export const Login: React.FunctionComponent<LoginProps> = (props) => {
     const { size } = props
     const { openSpotifyAccountLogin, redirect } = useAuth()
     return (
-        <Box align="center" justify="center" fill flex>
+        <Box align="center" justify="center" fill flex pad="medium">
             <motion.div
                 style={{ width: "100%", height: "100%" }}
                 className="container"
@@ -51,11 +51,19 @@ export const Login: React.FunctionComponent<LoginProps> = (props) => {
                             >
                                 m
                                 <Happy
+                                    onClick={() =>
+                                        window.open("https://www.youtube.com/watch?v=Tw0zYd0eIlk")
+                                    }
+                                    style={{ cursor: "pointer" }}
                                     width={size !== "small" ? "48px" : "24px"}
                                     height={size !== "small" ? "48px" : "24px"}
                                     id="happy-emoji"
                                 />
                                 <Sad
+                                    onClick={() =>
+                                        window.open("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+                                    }
+                                    style={{ cursor: "pointer" }}
                                     width={size !== "small" ? "48px" : "24px"}
                                     height={size !== "small" ? "48px" : "24px"}
                                     id="sad-emoji"

--- a/components/login/login.tsx
+++ b/components/login/login.tsx
@@ -30,7 +30,7 @@ export const Login: React.FunctionComponent<LoginProps> = (props) => {
                     round="large"
                     border={{
                         side: "all",
-                        size: "xlarge",
+                        size: "large",
                         style: "outset",
                         color: "accent-1",
                     }}

--- a/components/results/result-list-item/result-list-item.spec.tsx
+++ b/components/results/result-list-item/result-list-item.spec.tsx
@@ -19,7 +19,7 @@ describe("<ResultListItem />", () => {
 
     it("renders the track name", () => {
         const wrapper = render(
-            <ResultListItem size={"small"} dispatch={jest.fn()} track={mockTrack} />
+            <ResultListItem size={"large"} dispatch={jest.fn()} track={mockTrack} />
         )
 
         expect(wrapper.text()).to.contain(mockTrack.name)
@@ -27,7 +27,7 @@ describe("<ResultListItem />", () => {
 
     it("renders the track artist", () => {
         const wrapper = render(
-            <ResultListItem size={"small"} dispatch={jest.fn()} track={mockTrack} />
+            <ResultListItem size={"large"} dispatch={jest.fn()} track={mockTrack} />
         )
 
         expect(wrapper.text()).to.contain(mockTrack.artist)

--- a/components/results/result-list-item/result-list-item.tsx
+++ b/components/results/result-list-item/result-list-item.tsx
@@ -3,7 +3,7 @@ import { Box, Image, Text, Button } from "grommet"
 import { Track } from "../../../types/Track"
 import { More, SubtractCircle } from "grommet-icons"
 import { remove, updateTrackToShow } from "../reducer"
-import { getShortenedTrackName } from "../../../common/Helpers"
+import { getShortenedName } from "../../../common/Helpers"
 import { motion } from "framer-motion"
 
 interface ResultListItemProps {
@@ -27,10 +27,14 @@ export const ResultListItem: FunctionComponent<ResultListItemProps> = (props) =>
             }}
             pad={{
                 vertical: "xlarge",
-                horizontal: size !== "small" ? "xlarge" : "large",
+                horizontal: "large",
             }}
             align="center"
-            border={{ side: "all", size: "medium", color: "accent-3" }}
+            border={{
+                side: "all",
+                size: size !== "small" ? "medium" : "small",
+                color: "accent-3",
+            }}
         >
             <Box
                 gap="small"
@@ -43,18 +47,37 @@ export const ResultListItem: FunctionComponent<ResultListItemProps> = (props) =>
             >
                 <Box direction="row" align="center" gap="small" round="small">
                     <Box
+                        background={{
+                            color: size !== "small" ? "#1F2730" : undefined,
+                            opacity: 0.6,
+                        }}
+                        pad={size !== "small" ? "xsmall" : "none"}
+                        round="small"
                         align="center"
-                        width={size === "large" ? "120px" : size === "medium" ? "96px" : "72px"}
-                        height={size === "large" ? "120px" : size === "medium" ? "96px" : "72px"}
+                        width={size === "large" ? "144px" : size === "medium" ? "120px" : "72px"}
+                        height={size === "large" ? "144px" : size === "medium" ? "120px" : "72px"}
                     >
                         <Image fill alignSelf="center" src={track.imageLink} fit="contain" />
                     </Box>
                     <Box align="start">
-                        <Text textAlign="start" weight="bold" size={size}>
-                            {size === "small" ? getShortenedTrackName(track.name) : track.name}
+                        <Text
+                            textAlign="start"
+                            weight="bold"
+                            size={
+                                size === "large" ? "xxlarge" : size === "medium" ? "xlarge" : size
+                            }
+                        >
+                            {size === "small" ? getShortenedName(track.name, true) : track.name}
                         </Text>
-                        <Text textAlign="start" size={size !== "small" ? "small" : "xsmall"}>
-                            {track.artist}
+                        <Text
+                            textAlign="start"
+                            size={
+                                size === "large" ? "medium" : size === "medium" ? "small" : "xsmall"
+                            }
+                        >
+                            {size === "small"
+                                ? getShortenedName(track.artist, false)
+                                : track.artist}
                         </Text>
                     </Box>
                 </Box>
@@ -64,9 +87,9 @@ export const ResultListItem: FunctionComponent<ResultListItemProps> = (props) =>
                         title="more"
                         style={{ borderRadius: 30 }}
                         alignSelf="center"
-                        icon={<More size={size === "large" ? "large" : "medium"} />}
-                        size={size}
-                        hoverIndicator="dark-1"
+                        icon={<More size={size !== "small" ? "large" : "medium"} />}
+                        size={size !== "small" ? "large" : "small"}
+                        hoverIndicator="#24C0FF"
                         onClick={() => dispatch(updateTrackToShow("trackToShow", track))}
                     />
                 </motion.div>
@@ -78,11 +101,11 @@ export const ResultListItem: FunctionComponent<ResultListItemProps> = (props) =>
                         hoverIndicator="dark-1"
                         alignSelf="center"
                         title="remove from moodqueue"
-                        size={size === "large" ? "large" : "medium"}
+                        size="large"
                         icon={
                             <SubtractCircle
                                 color="status-error"
-                                size={size === "large" ? "large" : "medium"}
+                                size={size !== "small" ? "large" : "medium"}
                             />
                         }
                         style={{ borderRadius: 30 }}

--- a/components/results/result-list-item/result-list-item.tsx
+++ b/components/results/result-list-item/result-list-item.tsx
@@ -10,9 +10,10 @@ interface ResultListItemProps {
     track: Track
     size: any
     dispatch: any
+    align: string
 }
 export const ResultListItem: FunctionComponent<ResultListItemProps> = (props) => {
-    const { track, size, dispatch } = props
+    const { track, size, dispatch, align } = props
     return (
         <Box
             overflow={{ vertical: "hidden" }}
@@ -23,13 +24,19 @@ export const ResultListItem: FunctionComponent<ResultListItemProps> = (props) =>
                 borderTopRightRadius: 30,
                 borderBottomLeftRadius: 30,
                 background:
-                    "linear-gradient(215deg, rgba(63,94,251,1) 30%, rgba(252,70,107,1) 100%)",
+                    align === "start"
+                        ? "linear-gradient(215deg, rgba(63,94,251,1) 30%, rgba(252,70,107,1) 100%)"
+                        : align === "end"
+                        ? "linear-gradient(215deg, rgba(252,70,107,1) 0%, rgba(63,94,251,1) 60%)"
+                        : "radial-gradient(circle, rgba(63,94,251,1) 30%, rgba(252,70,107,1) 100%)",
+                width: "70%",
             }}
             pad={{
-                vertical: "xlarge",
+                vertical: "large",
                 horizontal: "large",
             }}
             align="center"
+            alignSelf={align === "start" ? "start" : align === "end" ? "end" : "center"}
             border={{
                 side: "all",
                 size: size !== "small" ? "medium" : "small",
@@ -54,8 +61,8 @@ export const ResultListItem: FunctionComponent<ResultListItemProps> = (props) =>
                         pad={size !== "small" ? "xsmall" : "none"}
                         round="small"
                         align="center"
-                        width={size === "large" ? "144px" : size === "medium" ? "120px" : "72px"}
-                        height={size === "large" ? "144px" : size === "medium" ? "120px" : "72px"}
+                        width={size === "large" ? "84px" : size === "medium" ? "72px" : "72px"}
+                        height={size === "large" ? "84px" : size === "medium" ? "72px" : "72px"}
                     >
                         <Image fill alignSelf="center" src={track.imageLink} fit="contain" />
                     </Box>
@@ -63,9 +70,7 @@ export const ResultListItem: FunctionComponent<ResultListItemProps> = (props) =>
                         <Text
                             textAlign="start"
                             weight="bold"
-                            size={
-                                size === "large" ? "xxlarge" : size === "medium" ? "xlarge" : size
-                            }
+                            size={size === "large" ? "xlarge" : size === "medium" ? "large" : size}
                         >
                             {size === "small" ? getShortenedName(track.name, true) : track.name}
                         </Text>
@@ -87,9 +92,10 @@ export const ResultListItem: FunctionComponent<ResultListItemProps> = (props) =>
                         title="more"
                         style={{ borderRadius: 30 }}
                         alignSelf="center"
-                        icon={<More size={size !== "small" ? "large" : "medium"} />}
-                        size={size !== "small" ? "large" : "small"}
-                        hoverIndicator="#24C0FF"
+                        //color="#24C0FF"
+                        icon={<More />}
+                        size={size !== "small" ? "medium" : "small"}
+                        //hoverIndicator="#24C0FF"
                         onClick={() => dispatch(updateTrackToShow("trackToShow", track))}
                     />
                 </motion.div>
@@ -100,14 +106,10 @@ export const ResultListItem: FunctionComponent<ResultListItemProps> = (props) =>
                         id="remove-track-btn"
                         hoverIndicator="dark-1"
                         alignSelf="center"
+                        primary
+                        color="dark-1"
                         title="remove from moodqueue"
-                        size="large"
-                        icon={
-                            <SubtractCircle
-                                color="status-error"
-                                size={size !== "small" ? "large" : "medium"}
-                            />
-                        }
+                        icon={<SubtractCircle color="status-error" />}
                         style={{ borderRadius: 30 }}
                         onClick={() => dispatch(remove("tracks", track.id))}
                     />

--- a/components/results/result-list-item/result-list-item.tsx
+++ b/components/results/result-list-item/result-list-item.tsx
@@ -10,7 +10,7 @@ interface ResultListItemProps {
     track: Track
     size: any
     dispatch: any
-    align: string
+    align?: string
 }
 export const ResultListItem: FunctionComponent<ResultListItemProps> = (props) => {
     const { track, size, dispatch, align } = props
@@ -24,16 +24,22 @@ export const ResultListItem: FunctionComponent<ResultListItemProps> = (props) =>
                 borderTopRightRadius: 30,
                 borderBottomLeftRadius: 30,
                 background:
-                    align === "start"
+                    !align || align === "start"
                         ? "linear-gradient(215deg, rgba(63,94,251,1) 30%, rgba(252,70,107,1) 100%)"
                         : align === "end"
                         ? "linear-gradient(215deg, rgba(252,70,107,1) 0%, rgba(63,94,251,1) 60%)"
-                        : "radial-gradient(circle, rgba(63,94,251,1) 30%, rgba(252,70,107,1) 100%)",
-                width: "70%",
+                        : "radial-gradient(circle, rgba(63,94,251,1) 25%, rgba(252,70,107,1) 100%)",
+                width: align
+                    ? size === "large"
+                        ? "70%"
+                        : size === "medium"
+                        ? "80%"
+                        : "90%"
+                    : "100%",
             }}
             pad={{
-                vertical: "large",
-                horizontal: "large",
+                vertical: size !== "small" ? "large" : "xlarge",
+                horizontal: size !== "small" ? "medium" : "large",
             }}
             align="center"
             alignSelf={align === "start" ? "start" : align === "end" ? "end" : "center"}
@@ -92,8 +98,9 @@ export const ResultListItem: FunctionComponent<ResultListItemProps> = (props) =>
                         title="more"
                         style={{ borderRadius: 30 }}
                         alignSelf="center"
+                        focusIndicator={false}
                         //color="#24C0FF"
-                        icon={<More />}
+                        icon={<More size={size === "large" ? "large" : "medium"} />}
                         size={size !== "small" ? "medium" : "small"}
                         //hoverIndicator="#24C0FF"
                         onClick={() => dispatch(updateTrackToShow("trackToShow", track))}
@@ -109,7 +116,7 @@ export const ResultListItem: FunctionComponent<ResultListItemProps> = (props) =>
                         primary
                         color="dark-1"
                         title="remove from moodqueue"
-                        icon={<SubtractCircle color="status-error" />}
+                        icon={<SubtractCircle color="status-error" size={size} />}
                         style={{ borderRadius: 30 }}
                         onClick={() => dispatch(remove("tracks", track.id))}
                     />

--- a/components/results/result-list/result-list.spec.tsx
+++ b/components/results/result-list/result-list.spec.tsx
@@ -34,12 +34,14 @@ const mockTracks: Track[] = [
 
 describe("<ResultList />", () => {
     it("renders without crashing", () => {
-        render(<ResultList tracks={mockTracks} size={"large"} dispatch={jest.fn()} />)
+        render(
+            <ResultList tracks={mockTracks} size={"large"} dispatch={jest.fn()} layout={"fun"} />
+        )
     })
 
     it("renders a <ResultListItem /> for each track", () => {
         const wrapper = shallow(
-            <ResultList tracks={mockTracks} size={"large"} dispatch={jest.fn()} />
+            <ResultList tracks={mockTracks} size={"large"} dispatch={jest.fn()} layout={"fun"} />
         )
 
         expect(wrapper.find(ResultListItem)).to.have.length(mockTracks.length)

--- a/components/results/result-list/result-list.tsx
+++ b/components/results/result-list/result-list.tsx
@@ -5,12 +5,13 @@ import { ResultListItem } from "../result-list-item/result-list-item"
 
 interface ResultListProps {
     tracks: Track[]
+    layout: string
     dispatch: any
     size: any
 }
 
 export const ResultList: FunctionComponent<ResultListProps> = (props) => {
-    const { tracks, dispatch, size } = props
+    const { tracks, dispatch, size, layout } = props
     return (
         <Box
             overflow={{ vertical: "auto" }}
@@ -19,7 +20,7 @@ export const ResultList: FunctionComponent<ResultListProps> = (props) => {
             justify={tracks ? (tracks.length > 1 ? "start" : "center") : "center"}
             pad={{
                 vertical: "small",
-                horizontal: size !== "small" ? "xlarge" : "none",
+                horizontal: size !== "small" ? "medium" : "none",
             }}
             fill
         >
@@ -29,7 +30,15 @@ export const ResultList: FunctionComponent<ResultListProps> = (props) => {
                     track={track}
                     size={size}
                     dispatch={dispatch}
-                    align={i % 2 !== 0 ? "center" : i % 4 === 0 ? "start" : "end"}
+                    align={
+                        layout === "fun"
+                            ? i % 2 !== 0 || tracks.length <= 1
+                                ? "center"
+                                : i % 4 === 0
+                                ? "start"
+                                : "end"
+                            : undefined
+                    }
                 />
             ))}
         </Box>

--- a/components/results/result-list/result-list.tsx
+++ b/components/results/result-list/result-list.tsx
@@ -24,7 +24,13 @@ export const ResultList: FunctionComponent<ResultListProps> = (props) => {
             fill
         >
             {tracks.map((track, i) => (
-                <ResultListItem key={i} track={track} size={size} dispatch={dispatch} />
+                <ResultListItem
+                    key={i}
+                    track={track}
+                    size={size}
+                    dispatch={dispatch}
+                    align={i % 2 !== 0 ? "center" : i % 4 === 0 ? "start" : "end"}
+                />
             ))}
         </Box>
     )

--- a/components/results/results.spec.tsx
+++ b/components/results/results.spec.tsx
@@ -7,7 +7,7 @@ import { Mood } from "../../types/Mood"
 import { SpotifyContextValue, SpotifyProvider } from "../../common/hooks/useSpotify"
 import { Track } from "../../types/Track"
 import { act } from "react-dom/test-utils"
-import { BounceLoader } from "react-spinners"
+
 import { ResultList } from "./result-list"
 
 const source: FormSelection = {
@@ -40,6 +40,7 @@ describe("<Results />", () => {
     it("renders without crashing", () => {
         shallow(
             <Results
+                layout={"fun"}
                 tracks={mockTracks}
                 size={"large"}
                 mood={0}
@@ -52,6 +53,7 @@ describe("<Results />", () => {
     it("renders mood name in title", () => {
         const wrapper = render(
             <Results
+                layout={"fun"}
                 size={"large"}
                 mood={Mood.SLEEPY}
                 tracks={mockTracks}
@@ -66,6 +68,7 @@ describe("<Results />", () => {
     it("renders 'loading...' for number of tracks when tracks are loading", () => {
         const wrapper = render(
             <Results
+                layout={"fun"}
                 size={"large"}
                 mood={Mood.SLEEPY}
                 tracks={mockTracks}
@@ -91,6 +94,7 @@ describe("<Results />", () => {
         const TestComponent = () => (
             <SpotifyProvider value={contextValues}>
                 <Results
+                    layout={"fun"}
                     size={"large"}
                     mood={Mood.SLEEPY}
                     tracks={mockTracks}
@@ -121,6 +125,7 @@ describe("<Results />", () => {
     it("renders queue sources in description", () => {
         const wrapper = render(
             <Results
+                layout={"fun"}
                 size={"large"}
                 mood={Mood.SLEEPY}
                 tracks={mockTracks}
@@ -145,6 +150,7 @@ describe("<Results />", () => {
         const TestComponent = () => (
             <SpotifyProvider value={contextValues}>
                 <Results
+                    layout={"fun"}
                     size={"large"}
                     mood={Mood.SLEEPY}
                     tracks={mockTracks}
@@ -186,6 +192,7 @@ describe("<Results />", () => {
         const TestComponent = () => (
             <SpotifyProvider value={contextValues}>
                 <Results
+                    layout={"fun"}
                     size={"large"}
                     mood={Mood.SLEEPY}
                     tracks={[]}
@@ -216,6 +223,7 @@ describe("<Results />", () => {
     it("renders play queue button", () => {
         const wrapper = render(
             <Results
+                layout={"fun"}
                 size={"large"}
                 mood={Mood.SLEEPY}
                 tracks={mockTracks}
@@ -229,6 +237,7 @@ describe("<Results />", () => {
     it("renders start over button", () => {
         const wrapper = render(
             <Results
+                layout={"fun"}
                 size={"large"}
                 mood={Mood.SLEEPY}
                 tracks={mockTracks}
@@ -254,6 +263,7 @@ describe("<Results />", () => {
         const TestComponent = () => (
             <SpotifyProvider value={contextValues}>
                 <Results
+                    layout={"fun"}
                     size={"large"}
                     mood={Mood.SLEEPY}
                     tracks={mockTracks}
@@ -297,6 +307,7 @@ describe("<Results />", () => {
         const TestComponent = () => (
             <SpotifyProvider value={contextValues}>
                 <Results
+                    layout={"fun"}
                     size={"large"}
                     mood={Mood.SLEEPY}
                     tracks={mockTracks}

--- a/components/results/results.tsx
+++ b/components/results/results.tsx
@@ -51,6 +51,7 @@ export const Results: FunctionComponent<ResultsProps> = (props) => {
                 id="desc-title"
                 textAlign="center"
                 size="small"
+                header
                 text={`here's your ${mood >= 0 ? Mood[mood].toLowerCase() + " queue:" : " queue:"}`}
             />
             <Box direction="row" border="between" gap="small" align="center">
@@ -90,7 +91,9 @@ export const Results: FunctionComponent<ResultsProps> = (props) => {
                         <Description
                             textAlign="center"
                             size={size !== "small" ? "medium" : "small"}
-                            text="click the start over button below to make a new moodqueue!"
+                            text={`click the ${
+                                size === "small" ? "back" : "start over"
+                            } button below to make a new moodqueue!`}
                         />
                     </Box>
                 ) : (
@@ -120,12 +123,11 @@ export const Results: FunctionComponent<ResultsProps> = (props) => {
                 <Button
                     id="play-queue-btn"
                     title="play your moodqueue"
-                    text={size === "small" ? undefined : "start queue"}
-                    icon={<CirclePlay />}
+                    text={size === "small" ? "play" : "play queue"}
+                    icon={<CirclePlay color="dark-2" />}
                     onClick={() => {
                         addToQueue(state.tracks)
                     }}
-                    hover="accent-1"
                 />
                 <Options
                     size={size}
@@ -136,10 +138,10 @@ export const Results: FunctionComponent<ResultsProps> = (props) => {
                 <Button
                     id="reset-btn"
                     title="start over to begin a new moodqueue"
-                    icon={<Previous />}
-                    text={size === "small" ? undefined : "start over"}
+                    icon={<Previous color="dark-2" />}
+                    text={size === "small" ? "back" : "start over"}
                     onClick={resetForm}
-                    hover="accent-3"
+                    secondary
                     //color="accent-3"
                 />
             </Box>

--- a/components/results/results.tsx
+++ b/components/results/results.tsx
@@ -43,22 +43,8 @@ export const Results: FunctionComponent<ResultsProps> = (props) => {
     }, [])
 
     return (
-        <Box
-            align="center"
-            justify="between"
-            gap="small"
-            fill
-            pad={{
-                horizontal: "medium",
-                vertical: "small",
-            }}
-        >
-            <Heading
-                id="desc-title"
-                textAlign="center"
-                margin="none"
-                size={size !== "small" ? "medium" : "small"}
-            >
+        <Box align="center" justify="between" gap="small" fill>
+            <Heading id="desc-title" textAlign="center" margin="none" size="small">
                 here's your {mood >= 0 ? Mood[mood].toLowerCase() + " queue:" : " queue:"}
             </Heading>
             <Box direction="row" border="between" gap="small" align="center">
@@ -84,7 +70,6 @@ export const Results: FunctionComponent<ResultsProps> = (props) => {
                 justify={state.tracks ? (state.tracks.length > 1 ? "start" : "center") : "center"}
                 pad={{
                     vertical: size === "small" ? "small" : "none",
-                    horizontal: size !== "small" ? "xlarge" : "none",
                 }}
                 fill
             >

--- a/components/results/results.tsx
+++ b/components/results/results.tsx
@@ -22,6 +22,7 @@ import { baseItemTop } from "../animations/motion"
 
 interface ResultsProps {
     size: string
+    layout: string
     tracks: Track[]
     mood: Mood
     source: FormSelection
@@ -29,7 +30,7 @@ interface ResultsProps {
 }
 
 export const Results: FunctionComponent<ResultsProps> = (props) => {
-    const { size, tracks, source, mood, resetForm } = props
+    const { size, tracks, source, mood, resetForm, layout } = props
     const { addToQueue } = useSpotify()
 
     const [state, dispatch] = useReducer<Reducer<ResultState, ResultAction>>(
@@ -72,30 +73,35 @@ export const Results: FunctionComponent<ResultsProps> = (props) => {
                     vertical: size === "small" ? "small" : "none",
                 }}
                 fill
+                flex
             >
-                <motion.div
-                    className="item"
-                    variants={baseItemTop}
-                    style={{ width: "100%", height: "100%" }}
-                >
-                    {state.tracks && state.tracks.length === 0 ? (
-                        <Box align="center" gap="small">
-                            <Text textAlign="center" size={size} weight="bold">
-                                oops! no more songs
-                            </Text>
-                            <Sad width="48px" height="48px" />
-                            <Text textAlign="center" size={size !== "small" ? "medium" : "small"}>
-                                click the start over button below to make a new moodqueue!
-                            </Text>
-                        </Box>
-                    ) : (
+                {state.tracks && state.tracks.length === 0 ? (
+                    <Box align="center" gap="small" justify="center">
+                        <Text textAlign="center" size={size} weight="bold">
+                            oops! no more songs
+                        </Text>
+                        <Sad width="48px" height="48px" />
+                        <Text textAlign="center" size={size !== "small" ? "medium" : "small"}>
+                            click the start over button below to make a new moodqueue!
+                        </Text>
+                    </Box>
+                ) : (
+                    <motion.div
+                        className="item"
+                        variants={baseItemTop}
+                        style={{
+                            width: "100%",
+                            height: "100%",
+                        }}
+                    >
                         <ResultList
+                            layout={layout}
                             tracks={state.tracks || props.tracks}
                             dispatch={(value) => dispatch(value)}
                             size={size}
                         />
-                    )}
-                </motion.div>
+                    </motion.div>
+                )}
             </Box>
             <Box
                 direction="row"

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -46,7 +46,6 @@ const BaseApp: FunctionComponent = () => {
                     <Box
                         align="center"
                         justify="center"
-                        pad="medium"
                         fill
                         style={{
                             background:

--- a/ui/backgrounds/index/IndexBackground.tsx
+++ b/ui/backgrounds/index/IndexBackground.tsx
@@ -4,7 +4,7 @@ import { IndexBackgroundOuter } from "../Background.styles"
 
 export const Index: React.FunctionComponent = (props) => {
     return (
-        <IndexBackgroundOuter id="index-outer-box" pad="medium" background="#1F2730">
+        <IndexBackgroundOuter id="index-outer-box" background="#1F2730">
             {
                 <Head>
                     <meta

--- a/ui/backgrounds/login/LoginBackground.tsx
+++ b/ui/backgrounds/login/LoginBackground.tsx
@@ -18,7 +18,7 @@ export const LoginBackground: React.FunctionComponent = (props) => {
                     background={{ color: "#2F3E4D", opacity: 0.7 }}
                     border={{
                         side: "all",
-                        size: "xlarge",
+                        size: "large",
                         style: "outset",
                         color: "accent-1",
                     }}

--- a/ui/button/Button.styles.ts
+++ b/ui/button/Button.styles.ts
@@ -4,11 +4,9 @@ import { Button as GrommetButton } from "grommet"
 export const PrimaryButton = styled(GrommetButton)`
     border-radius: 30px;
     border: none;
-    color: #666666;
 `
 
 export const SecondaryButton = styled(GrommetButton)`
     border-radius: 30px;
     border: none;
-    color: #666666;
 `

--- a/ui/button/Button.tsx
+++ b/ui/button/Button.tsx
@@ -1,7 +1,6 @@
 import React from "react"
 import { motion } from "framer-motion"
 import { PrimaryButton, SecondaryButton } from "./Button.styles"
-import { baseItemTop } from "../../components/animations/motion"
 
 interface ButtonProps {
     id?: string
@@ -9,36 +8,46 @@ interface ButtonProps {
     icon?: any
     disabled?: any
     fill?: boolean
+    margin?: any
     onClick?: () => void
     small?: boolean
     secondary?: boolean
     hover?: any
     title?: any
+    color?: any
 }
 export const Button: React.FunctionComponent<ButtonProps> = (props) => {
-    const { id, text, icon, onClick, disabled, small, secondary, hover, title, fill } = props
+    const {
+        id,
+        text,
+        icon,
+        onClick,
+        disabled,
+        margin,
+        small,
+        secondary,
+        hover,
+        title,
+        fill,
+        color,
+    } = props
 
     if (small && secondary) {
         return (
-            <motion.div
-                whileHover={{ scale: 1.1 }}
-                whileTap={{ scale: 0.9 }}
-                className="item"
-                variants={baseItemTop}
-            >
+            <motion.div whileHover={{ scale: 1.1 }} whileTap={{ scale: 0.9 }}>
                 <SecondaryButton
                     id={id}
                     icon={icon}
                     onClick={onClick}
                     disabled={disabled}
-                    margin={"small"}
                     alignSelf="center"
-                    size="small"
                     hoverIndicator={hover}
                     title={title}
-                    color="accent-3"
                     primary={fill === undefined ? true : fill}
                     label={text}
+                    margin={margin}
+                    color={color === undefined ? "accent-3" : color}
+                    focusIndicator={false}
                 />
             </motion.div>
         )
@@ -51,14 +60,14 @@ export const Button: React.FunctionComponent<ButtonProps> = (props) => {
                     icon={icon}
                     onClick={onClick}
                     disabled={disabled}
-                    margin={"small"}
                     alignSelf="center"
-                    size="small"
                     hoverIndicator={hover}
                     title={title}
-                    color="accent-1"
+                    color={color === undefined ? "accent-1" : color}
                     primary={fill === undefined ? true : fill}
                     label={text}
+                    margin={margin}
+                    focusIndicator={false}
                 />
             </motion.div>
         )
@@ -73,12 +82,13 @@ export const Button: React.FunctionComponent<ButtonProps> = (props) => {
                     onClick={onClick}
                     disabled={disabled}
                     alignSelf="center"
-                    margin={"small"}
                     size="large"
                     hoverIndicator={hover}
                     title={title}
-                    color="accent-3"
+                    color={color === undefined ? "accent-3" : color}
                     primary={fill === undefined ? true : fill}
+                    margin={margin}
+                    focusIndicator={false}
                 />
             </motion.div>
         )
@@ -92,12 +102,13 @@ export const Button: React.FunctionComponent<ButtonProps> = (props) => {
                 onClick={onClick}
                 disabled={disabled}
                 alignSelf="center"
-                margin={"small"}
                 size="large"
                 hoverIndicator={hover}
                 title={title}
-                color="accent-1"
+                color={color === undefined ? "accent-1" : color}
                 primary={fill === undefined ? true : fill}
+                margin={margin}
+                focusIndicator={false}
             />
         </motion.div>
     )

--- a/ui/moodButton/MoodButton.tsx
+++ b/ui/moodButton/MoodButton.tsx
@@ -10,21 +10,19 @@ import { Mood } from "../../types/Mood"
 
 interface MoodButtonProps {
     id?: string
-    key?: any
     mood?: string
     onClick?: () => void
     size?: any
     selected?: boolean
 }
 export const MoodButton: React.FunctionComponent<MoodButtonProps> = (props) => {
-    const { id, mood, onClick, size, key, selected } = props
+    const { id, mood, onClick, size, selected } = props
 
     return (
         <motion.div whileHover={{ scale: 1.1 }} whileTap={{ scale: 0.9 }}>
             <MoodBox
                 id={id}
-                key={key}
-                hoverIndicator={selected ? "accent-3" : "accent-1"}
+                hoverIndicator="accent-3"
                 background={selected ? "accent-1" : "light-2"}
                 focusIndicator={false}
                 onClick={onClick}
@@ -35,18 +33,24 @@ export const MoodButton: React.FunctionComponent<MoodButtonProps> = (props) => {
                 }}
             >
                 {size !== "small" && (
-                    <Text size="xsmall" weight="bold" textAlign="center" id="mood-txt">
+                    <Text
+                        size="xsmall"
+                        weight="bold"
+                        textAlign="center"
+                        id="mood-txt"
+                        color="#555555"
+                    >
                         {Mood[mood].toLowerCase()}
                     </Text>
                 )}
                 {mood === Mood.HAPPY.toString() ? (
-                    <Happy width="32px" height="32px" id="happy-emoji" />
+                    <Happy width="32px" height="32px" id="happy-emoji" color="#555555" />
                 ) : mood === Mood.SLEEPY.toString() ? (
-                    <Sleepy width="32px" height="32px" id="sleepy-emoji" />
+                    <Sleepy width="32px" height="32px" id="sleepy-emoji" color="#555555" />
                 ) : mood === Mood.PARTY.toString() ? (
-                    <Party width="32px" height="32px" id="party-emoji" />
+                    <Party width="32px" height="32px" id="party-emoji" color="#555555" />
                 ) : (
-                    <Sad width="32px" height="32px" id="sad-emoji" />
+                    <Sad width="32px" height="32px" id="sad-emoji" color="#555555" />
                 )}
             </MoodBox>
         </motion.div>

--- a/ui/number-selector/NumberSelector.tsx
+++ b/ui/number-selector/NumberSelector.tsx
@@ -19,6 +19,7 @@ export const NumberSelector: React.FunctionComponent<NumberSelectorProps> = (pro
             {size !== "small" && (
                 <motion.div whileHover={{ scale: 1.1 }} whileTap={{ scale: 0.9 }}>
                     <Button
+                        margin="small"
                         id="subtract-btn"
                         icon={<Subtract size={size !== "small" ? "medium" : "small"} />}
                         onClick={onClickSubtract}
@@ -39,6 +40,7 @@ export const NumberSelector: React.FunctionComponent<NumberSelectorProps> = (pro
             {size !== "small" && (
                 <motion.div whileHover={{ scale: 1.1 }} whileTap={{ scale: 0.9 }}>
                     <Button
+                        margin="small"
                         id="add-btn"
                         icon={<Add size={size !== "small" ? "medium" : "small"} />}
                         onClick={onClickAdd}

--- a/ui/track/Track.tsx
+++ b/ui/track/Track.tsx
@@ -88,8 +88,7 @@ export const Track: React.FunctionComponent<TrackProps> = (props) => {
                 <Button
                     id="more-details-btn"
                     title="more"
-                    //focusIndicator={false}
-                    //color="#24C0FF"
+                    fill={false}
                     icon={<More size={size === "large" ? "large" : "medium"} />}
                     small={size === "small"}
                     hover="#24C0FF"
@@ -99,8 +98,7 @@ export const Track: React.FunctionComponent<TrackProps> = (props) => {
             {size !== "small" && (
                 <Button
                     id="remove-track-btn"
-                    hover="dark-1"
-                    //color="dark-1"
+                    color="dark-1"
                     title="remove from moodqueue"
                     icon={<SubtractCircle color="status-error" size={size} />}
                     onClick={onClickRemove}

--- a/ui/trackDetails/TrackDetails.tsx
+++ b/ui/trackDetails/TrackDetails.tsx
@@ -82,7 +82,7 @@ export const TrackDetails: React.FunctionComponent<TrackDetailsProps> = (props) 
                             small
                             icon={<SubtractCircle />}
                             text="remove from queue"
-                            secondary
+                            color="neutral-4"
                             onClick={onClickRemove}
                         />
                     )}


### PR DESCRIPTION
i reworked the layout of results so that it's a little more interesting to look at it and you can now see many more tracks on web than just two at a time (kates everywhere rejoice!).

also, i added in a settings layer with link to user's profile, a theme selector (for when we do gaegu, duh), and a toggle switch to toggle between layout types in results (the options are the fun way or the normal way).