### PR TITLE
recognize if user is free or premium

### DIFF
--- a/common/hooks/useAuth.tsx
+++ b/common/hooks/useAuth.tsx
@@ -61,6 +61,7 @@ export const AuthProvider: React.FunctionComponent<AuthProviderProps> = (props) 
             email: "",
             profileImages: [],
             profileUrl: "",
+            product: "",
         }
         const response = await fetch("https://api.spotify.com/v1/me", {
             headers: {
@@ -77,6 +78,7 @@ export const AuthProvider: React.FunctionComponent<AuthProviderProps> = (props) 
             email: data.email,
             profileImages: data.images,
             profileUrl: data.external_urls.spotify,
+            product: data.product,
         }
 
         setCurrentUser(newUser)

--- a/types/UserInfo.ts
+++ b/types/UserInfo.ts
@@ -6,6 +6,7 @@ export type UserInfo = {
     email: string
     profileUrl: string
     profileImages: Image[]
+    product: string
 }
 
 export const defaultUser: UserInfo = {
@@ -14,4 +15,5 @@ export const defaultUser: UserInfo = {
     email: "",
     profileUrl: "",
     profileImages: [],
+    product: "",
 }

--- a/ui/user-details/UserDetails.stories.tsx
+++ b/ui/user-details/UserDetails.stories.tsx
@@ -16,6 +16,7 @@ const user: UserInfo = {
                 "https://media.gq.com/photos/5d780edac517ca00085fee8a/16:9/w_2560%2Cc_limit/phoebe-bridgers-gq-october-2019-01-lede.jpg",
         },
     ],
+    product: "premium",
 }
 
 const user2: UserInfo = {
@@ -24,6 +25,7 @@ const user2: UserInfo = {
     email: "johndoe@aim.com",
     profileUrl: "yahoo.com",
     profileImages: [],
+    product: "free",
 }
 
 export const withProfilePicture = () => withGrommet(<UserDetails user={user} />)


### PR DESCRIPTION
added 'product' to our UserInfo type, and grabbed it off the request when we get user info. 

here's the documentation on the product value:
![image](https://user-images.githubusercontent.com/31379789/96205924-5ccfcf80-0f2d-11eb-9b74-7795433e2662.png)

so when we want to know the type of product a user has, we can say
```
const {user} = useAuth()

const productType = user.product // "free" | "premium", etc
```