### PR TITLE
Resolve patch/MOOD-60: misc fixes

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,4 @@
 {
-    "presets": [
-      "next/babel"
-    ]
-  } 
+  "plugins": ["styled-components"],
+  "presets": ["next/babel"]
+}

--- a/common/Helpers.ts
+++ b/common/Helpers.ts
@@ -46,14 +46,3 @@ export const getTrackSourceFromFormSelection = (formSelection: FormSelection): T
     }
     return result
 }
-
-export const getShortenedName = (name: string, track: boolean) => {
-    if (name.length <= (track ? 10 : 15)) {
-        return name
-    } else {
-        let temp: string = ""
-        temp = name.substring(0, track ? 9 : 14)
-        temp += "..."
-        return temp
-    }
-}

--- a/components/form/form.tsx
+++ b/components/form/form.tsx
@@ -7,7 +7,6 @@ import { SourceSelection } from "./souce"
 import { FormSelection } from "../../types/FormSelection"
 import { Mood } from "../../types/Mood"
 import { Button } from "../../ui/button/Button"
-import { Description } from "../../ui/description/Description"
 import { motion } from "framer-motion"
 import { baseItemBottom } from "../animations/motion"
 import { useSpotify } from "../../common/hooks/useSpotify"
@@ -15,7 +14,13 @@ import { BounceLoader } from "react-spinners"
 
 interface FormProps {
     size: string
-    handleSubmit(mood: Mood, numSongs: number, source: FormSelection, topGenres?: string[]): void
+    handleSubmit(
+        mood: Mood,
+        numSongs: number,
+        source: FormSelection,
+        selectedGenreValue: string,
+        topGenres?: string[]
+    ): void
 }
 
 export const Form: FunctionComponent<FormProps> = (props) => {
@@ -68,6 +73,7 @@ export const Form: FunctionComponent<FormProps> = (props) => {
                 <SourceSelection
                     size={size}
                     source={state.source}
+                    selectedGenreValue={state.genre}
                     progress={state.progress}
                     dispatch={(value) => dispatch(value)}
                     topGenres={topGenres}
@@ -77,9 +83,23 @@ export const Form: FunctionComponent<FormProps> = (props) => {
                     id="submit-form-btn"
                     text="continue"
                     onClick={() =>
-                        handleSubmit(state.mood, state.numSongs, state.source, selectedTopGenres)
+                        handleSubmit(
+                            state.mood,
+                            state.numSongs,
+                            state.source,
+                            state.genre,
+                            selectedTopGenres
+                        )
                     }
-                    disabled={state.progress !== 3}
+                    disabled={
+                        state.progress !== 3
+                            ? true
+                            : state.source.recommended
+                            ? state.genre
+                                ? false
+                                : true
+                            : false
+                    }
                 />
             </Box>
         </motion.div>

--- a/components/form/reducer.ts
+++ b/components/form/reducer.ts
@@ -5,6 +5,7 @@ export interface FormState {
     mood: Mood
     numSongs: number
     source: FormSelection
+    genre: string
     progress: number
 }
 
@@ -12,6 +13,7 @@ export const initialFormState: FormState = {
     mood: -1,
     numSongs: 0,
     source: defaultFormSelection,
+    genre: "",
     progress: 0,
 }
 
@@ -36,6 +38,7 @@ export const formReducer = (state: FormState, action: FormAction) => {
                 mood: -1,
                 numSongs: 0,
                 source: defaultFormSelection,
+                genre: "",
                 progress: 0,
                 showResults: false,
             }

--- a/components/form/souce/source.spec.tsx
+++ b/components/form/souce/source.spec.tsx
@@ -9,6 +9,7 @@ const exampleFormSelection: FormSelection = {
     artists: false,
     tracks: false,
     recommended: true,
+    genre: "",
 }
 
 describe("<SourceSelection />", () => {

--- a/components/form/souce/source.tsx
+++ b/components/form/souce/source.tsx
@@ -7,6 +7,7 @@ import { Sources } from "../../../ui/sources/Sources"
 interface SourceSelectionProps {
     progress: number
     source: FormSelection
+    selectedGenreValue: string
     size: string
     dispatch(value: FormAction): void
     topGenres: string[]
@@ -14,7 +15,15 @@ interface SourceSelectionProps {
 }
 
 export const SourceSelection: FunctionComponent<SourceSelectionProps> = (props) => {
-    const { size, source, progress, dispatch, topGenres, getSelectedGenres } = props
+    const {
+        size,
+        source,
+        selectedGenreValue,
+        progress,
+        dispatch,
+        topGenres,
+        getSelectedGenres,
+    } = props
 
     const updateProgressAfterCheckboxChange = (index: number, checked: boolean) => {
         const current = source
@@ -57,10 +66,11 @@ export const SourceSelection: FunctionComponent<SourceSelectionProps> = (props) 
             <Sources
                 size={size}
                 sources={source}
+                selectedGenreValue={selectedGenreValue}
                 topGenres={topGenres}
                 getSelectedGenres={getSelectedGenres}
                 onChange={(value, index) => {
-                    updateProgressAfterCheckboxChange(index, value)
+                    if (index !== 4) updateProgressAfterCheckboxChange(index, value)
                     switch (index) {
                         case 0:
                             dispatch(updateSourceSelection("saved", value))
@@ -73,6 +83,9 @@ export const SourceSelection: FunctionComponent<SourceSelectionProps> = (props) 
                             break
                         case 3:
                             dispatch(updateSourceSelection("recommended", value))
+                            break
+                        case 4:
+                            dispatch(update("genre", value))
                             break
                         default:
                             dispatch(updateSourceSelection("saved", value))

--- a/components/home/home.tsx
+++ b/components/home/home.tsx
@@ -24,6 +24,7 @@ export const Home: FunctionComponent<HomeProps> = (props) => {
     const [showResults, setShowResults] = useState(false)
     const [mood, setMood] = useState<Mood>(-1)
     const [source, setSource] = useState<FormSelection>(defaultFormSelection)
+    const [selectedGenreValue, setSelectedGenreValue] = useState("")
     const [tracks, setTracks] = useState<Track[]>()
     const [loading, setLoading] = useState(false)
     const { getQueue } = useSpotify()
@@ -51,6 +52,7 @@ export const Home: FunctionComponent<HomeProps> = (props) => {
                         tracks={tracks}
                         size={size}
                         mood={mood}
+                        selectedGenreValue={selectedGenreValue}
                         source={source}
                         resetForm={() => setShowResults(false)}
                         userProduct={user.product}
@@ -58,13 +60,20 @@ export const Home: FunctionComponent<HomeProps> = (props) => {
                 ) : (
                     <Form
                         size={size}
-                        handleSubmit={(mood, numSongs, source, topGenres?: string[]) => {
+                        handleSubmit={(
+                            mood,
+                            numSongs,
+                            source,
+                            selectedGenreValue,
+                            topGenres?: string[]
+                        ) => {
                             setLoading(true)
                             const trackSources = getTrackSourceFromFormSelection(source)
                             getQueue(trackSources, numSongs, mood, topGenres).then((data) => {
                                 setTracks(data)
                                 setMood(mood)
                                 setSource(source)
+                                setSelectedGenreValue(selectedGenreValue)
                                 setLoading(false)
                                 setShowResults(true)
                             })

--- a/components/results/results.tsx
+++ b/components/results/results.tsx
@@ -28,12 +28,13 @@ interface ResultsProps {
     tracks: Track[]
     mood: Mood
     source: FormSelection
+    selectedGenreValue: string
     resetForm(): void
     userProduct: string
 }
 
 export const Results: FunctionComponent<ResultsProps> = (props) => {
-    const { size, tracks, source, mood, resetForm, userProduct } = props
+    const { size, tracks, source, selectedGenreValue, mood, resetForm, userProduct } = props
     const { addToQueue, addToPlaylist } = useSpotify()
 
     const [state, dispatch] = useReducer<Reducer<ResultState, ResultAction>>(
@@ -67,7 +68,11 @@ export const Results: FunctionComponent<ResultsProps> = (props) => {
                         id="desc-sources"
                         textAlign="center"
                         size={size !== "small" ? "xlarge" : "medium"}
-                        text={"based off your " + getSourcesString(source)}
+                        text={`based off ${
+                            !selectedGenreValue
+                                ? "your " + getSourcesString(source)
+                                : selectedGenreValue.replace("-", " ")
+                        }`}
                     />
                 </Box>
                 <Box

--- a/ui/button/Button.styles.ts
+++ b/ui/button/Button.styles.ts
@@ -4,9 +4,11 @@ import { Button as GrommetButton } from "grommet"
 export const PrimaryButton = styled(GrommetButton)`
     border-radius: 30px;
     border: none;
+    align-self: center;
 `
 
 export const SecondaryButton = styled(GrommetButton)`
     border-radius: 30px;
     border: none;
+    align-self: center;
 `

--- a/ui/button/Button.tsx
+++ b/ui/button/Button.tsx
@@ -40,7 +40,6 @@ export const Button: React.FunctionComponent<ButtonProps> = (props) => {
                     icon={icon}
                     onClick={onClick}
                     disabled={disabled}
-                    alignSelf="center"
                     hoverIndicator={hover}
                     title={title}
                     primary={fill === undefined ? true : fill}
@@ -60,7 +59,6 @@ export const Button: React.FunctionComponent<ButtonProps> = (props) => {
                     icon={icon}
                     onClick={onClick}
                     disabled={disabled}
-                    alignSelf="center"
                     hoverIndicator={hover}
                     title={title}
                     color={color === undefined ? "accent-1" : color}
@@ -81,7 +79,6 @@ export const Button: React.FunctionComponent<ButtonProps> = (props) => {
                     label={text}
                     onClick={onClick}
                     disabled={disabled}
-                    alignSelf="center"
                     size="large"
                     hoverIndicator={hover}
                     title={title}
@@ -101,7 +98,6 @@ export const Button: React.FunctionComponent<ButtonProps> = (props) => {
                 label={text}
                 onClick={onClick}
                 disabled={disabled}
-                alignSelf="center"
                 size="large"
                 hoverIndicator={hover}
                 title={title}

--- a/ui/description/Description.styles.ts
+++ b/ui/description/Description.styles.ts
@@ -1,8 +1,0 @@
-import styled from "styled-components"
-import { Text as GrommetText, Heading as GrommetHeader } from "grommet"
-
-export const Text = styled(GrommetText)``
-
-export const Header = styled(GrommetHeader)`
-    margin: 0;
-`

--- a/ui/description/Description.tsx
+++ b/ui/description/Description.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { Header, Text } from "./Description.styles"
+import { Heading as Header, Text } from "grommet"
 
 interface DescProps {
     id?: string
@@ -20,7 +20,13 @@ export const Description: React.FunctionComponent<DescProps> = (props) => {
         )
     }
     return (
-        <Header id={id} size={size} textAlign={textAlign} style={{ userSelect: "none" }}>
+        <Header
+            id={id}
+            size={size}
+            textAlign={textAlign}
+            margin="none"
+            style={{ userSelect: "none" }}
+        >
             {text}
         </Header>
     )

--- a/ui/logo/Logo.styles.ts
+++ b/ui/logo/Logo.styles.ts
@@ -1,4 +1,0 @@
-import styled from "styled-components"
-import { Heading as GrommetHeader } from "grommet"
-
-export const LogoHeader = styled(GrommetHeader)``

--- a/ui/logo/Logo.tsx
+++ b/ui/logo/Logo.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { Mood as Happy } from "@styled-icons/material-twotone/Mood"
 import { MoodBad as Sad } from "@styled-icons/material-twotone/MoodBad"
-import { LogoHeader } from "./Logo.styles"
+import { Heading as LogoHeader } from "grommet"
 
 interface LogoProps {
     id?: string

--- a/ui/sources/Sources.spec.tsx
+++ b/ui/sources/Sources.spec.tsx
@@ -23,6 +23,7 @@ describe("<Sources />", () => {
                 },
                 topGenres: ["indie folk", "indie"],
                 getSelectedTopGenres: jest.fn(),
+                selectedGenreValue: "indie",
             })
         )
     })

--- a/ui/sources/Sources.stories.tsx
+++ b/ui/sources/Sources.stories.tsx
@@ -9,6 +9,7 @@ export default { title: "Sources" }
 export const sourcesNotChecked = () =>
     withGrommet(
         <Sources
+            selectedGenreValue={"indie"}
             size="large"
             sources={{
                 saved: false,
@@ -23,6 +24,7 @@ export const sourcesNotChecked = () =>
 export const sourcesChecked = () =>
     withGrommet(
         <Sources
+            selectedGenreValue={"indie"}
             size="large"
             sources={{
                 saved: true,

--- a/ui/sources/Sources.tsx
+++ b/ui/sources/Sources.tsx
@@ -17,7 +17,6 @@ interface SourcesProps {
 }
 export const Sources: React.FunctionComponent<SourcesProps> = (props) => {
     const { size, onChange, sources, selectedGenreValue, topGenres, getSelectedGenres } = props
-    //const [genreSelectValue, setGenreSelectValue] = React.useState('');
     const [showGenre, setShowGenre] = React.useState(false)
     const [isOpen, setIsOpen] = React.useState(false)
 

--- a/ui/sources/Sources.tsx
+++ b/ui/sources/Sources.tsx
@@ -10,19 +10,20 @@ import { trackDetailsVariants } from "../../components/animations/motion"
 interface SourcesProps {
     size?: any
     sources: FormSelection
+    selectedGenreValue: string
     topGenres: string[]
-    onChange?: (value: boolean, index: number) => void
+    onChange?: (value: any, index: number) => void
     getSelectedGenres: (genres: string[]) => void
 }
 export const Sources: React.FunctionComponent<SourcesProps> = (props) => {
-    const { size, onChange, sources, topGenres, getSelectedGenres } = props
-    const [genreSelectValue, setGenreSelectValue] = React.useState("")
+    const { size, onChange, sources, selectedGenreValue, topGenres, getSelectedGenres } = props
+    //const [genreSelectValue, setGenreSelectValue] = React.useState('');
     const [showGenre, setShowGenre] = React.useState(false)
     const [isOpen, setIsOpen] = React.useState(false)
 
     React.useEffect(() => {
-        getSelectedGenres([genreSelectValue])
-    }, [genreSelectValue])
+        getSelectedGenres([selectedGenreValue])
+    }, [selectedGenreValue])
 
     return (
         <Box align="center">
@@ -86,23 +87,24 @@ export const Sources: React.FunctionComponent<SourcesProps> = (props) => {
                                         id="genre-select"
                                         options={topGenres}
                                         onChange={({ option }) => {
-                                            setGenreSelectValue(option)
+                                            onChange(option, 4)
                                             onChange(true, 3)
                                         }}
                                         dropHeight="small"
                                         closeOnChange={false}
                                         placeholder="a genre"
                                         onSearch={(search) => {
-                                            setGenreSelectValue(
-                                                topGenres.find((o) => o.includes(search))
+                                            onChange(
+                                                topGenres.find((o) => o.includes(search)),
+                                                4
                                             )
                                         }}
-                                        value={genreSelectValue}
+                                        value={selectedGenreValue}
                                     />
                                 </Box>
                             ) : (
                                 <Box>
-                                    <Text size="xsmall">{genreSelectValue || "a genre"}</Text>
+                                    <Text size="xsmall">{selectedGenreValue || "a genre"}</Text>
                                 </Box>
                             )
                         }
@@ -110,14 +112,14 @@ export const Sources: React.FunctionComponent<SourcesProps> = (props) => {
                         onChange={(event) => {
                             if (size !== "small") {
                                 if (!event.target.checked) {
-                                    onChange(false, 3)
-                                    setGenreSelectValue("")
+                                    onChange("", 4)
                                 }
+                                onChange(event.target.checked, 3)
                             } else {
                                 setShowGenre(event.target.checked)
                                 setIsOpen(event.target.checked)
                                 onChange(event.target.checked, 3)
-                                if (!event.target.checked) setGenreSelectValue("")
+                                if (!event.target.checked) onChange("", 4)
                             }
                         }}
                     />
@@ -126,7 +128,7 @@ export const Sources: React.FunctionComponent<SourcesProps> = (props) => {
             {showGenre && size === "small" && (
                 <Layer
                     onClickOutside={() => {
-                        if (!genreSelectValue) {
+                        if (!selectedGenreValue) {
                             onChange(false, 3)
                         }
                         setIsOpen(false)
@@ -164,21 +166,24 @@ export const Sources: React.FunctionComponent<SourcesProps> = (props) => {
                             <Select
                                 options={topGenres}
                                 onChange={({ option }) => {
-                                    setGenreSelectValue(option)
+                                    onChange(option, 4)
                                     if (!sources.recommended) onChange(true, 3)
                                 }}
                                 dropHeight="small"
                                 closeOnChange
                                 placeholder="select a genre"
                                 onSearch={(search) => {
-                                    setGenreSelectValue(topGenres.find((o) => o.includes(search)))
+                                    onChange(
+                                        topGenres.find((o) => o.includes(search)),
+                                        4
+                                    )
                                 }}
-                                value={genreSelectValue}
+                                value={selectedGenreValue}
                             />
                             <Box align="center" direction="row" gap="medium">
                                 <Button
                                     small
-                                    disabled={!genreSelectValue}
+                                    disabled={!selectedGenreValue}
                                     icon={<Checkmark />}
                                     color="neutral-3"
                                     onClick={() => {
@@ -191,7 +196,7 @@ export const Sources: React.FunctionComponent<SourcesProps> = (props) => {
                                     icon={<Close />}
                                     color="neutral-4"
                                     onClick={() => {
-                                        setGenreSelectValue("")
+                                        onChange("", 4)
                                         onChange(false, 3)
                                         setIsOpen(false)
                                         setTimeout(() => setShowGenre(false), 500)

--- a/ui/track/Track.styles.ts
+++ b/ui/track/Track.styles.ts
@@ -2,7 +2,7 @@ import styled from "styled-components"
 import { Box as GrommetBox } from "grommet"
 
 export const OuterBox = styled(GrommetBox)`
-    overflow-y: hidden;
+    overflow: hidden;
     flex-direction: row;
     justify-content: space-between;
     display: flex;

--- a/ui/track/Track.tsx
+++ b/ui/track/Track.tsx
@@ -2,7 +2,6 @@ import React, { useState } from "react"
 import { OuterBox, InnerBoxStart } from "./Track.styles"
 import { Box, Image, Text } from "grommet"
 import { More, SubtractCircle, Trash } from "grommet-icons"
-import { getShortenedName } from "../../common/Helpers"
 import { Track as TrackType } from "../../types/Track"
 import { Button } from "../button/Button"
 import { MoonLoader } from "react-spinners"
@@ -89,6 +88,7 @@ export const Track: React.FunctionComponent<TrackProps> = (trackProps) => {
                 >
                     <Box direction="row" align="center" gap="small" round="small">
                         <Box
+                            flex={false}
                             background={{
                                 color: trackProps.size !== "small" ? "#1F2730" : undefined,
                                 opacity: 0.6,
@@ -126,42 +126,44 @@ export const Track: React.FunctionComponent<TrackProps> = (trackProps) => {
                                     fill
                                     alignSelf="center"
                                     src={track.imageLink}
-                                    fit="contain"
+                                    fit="cover"
                                 />
                             )}
                         </Box>
                         <Box align="start">
-                            <Text
-                                style={{ userSelect: "none" }}
-                                textAlign="start"
-                                weight="bold"
-                                size={
-                                    trackProps.size === "large"
-                                        ? "xxlarge"
-                                        : trackProps.size === "medium"
-                                        ? "xlarge"
-                                        : trackProps.size
-                                }
-                            >
-                                {trackProps.size === "small"
-                                    ? getShortenedName(track.name, true)
-                                    : track.name}
-                            </Text>
-                            <Text
-                                style={{ userSelect: "none" }}
-                                textAlign="start"
-                                size={
-                                    trackProps.size === "large"
-                                        ? "medium"
-                                        : trackProps.size === "medium"
-                                        ? "small"
-                                        : "xsmall"
-                                }
-                            >
-                                {trackProps.size === "small"
-                                    ? getShortenedName(track.artist, false)
-                                    : track.artist}
-                            </Text>
+                            <Box overflow="hidden">
+                                <Text
+                                    truncate
+                                    style={{ userSelect: "none" }}
+                                    textAlign="start"
+                                    weight="bold"
+                                    size={
+                                        trackProps.size === "large"
+                                            ? "xxlarge"
+                                            : trackProps.size === "medium"
+                                            ? "xlarge"
+                                            : trackProps.size
+                                    }
+                                >
+                                    {track.name}
+                                </Text>
+                            </Box>
+                            <Box overflow="hidden">
+                                <Text
+                                    truncate
+                                    style={{ userSelect: "none" }}
+                                    textAlign="start"
+                                    size={
+                                        trackProps.size === "large"
+                                            ? "medium"
+                                            : trackProps.size === "medium"
+                                            ? "small"
+                                            : "xsmall"
+                                    }
+                                >
+                                    {track.artist}
+                                </Text>
+                            </Box>
                         </Box>
                     </Box>
                     {!isDrag ? (


### PR DESCRIPTION
so, i was originally going to use this branch to mock out some sort of post queue/playlist page that would feature a share button and a back button and maybe some text instead of still showing the tracks. however, i got distracted and wanted to knock out some issues so that's what i did.

this branch has fixes for displaying large track names on the web without weird side effects. i actually forgot about the fact that grommet's text component comes with a prop called truncate, and when it's surrounded by a box or div, an ellipsis shows up automatically if there isn't enough room for the text. this is a lot more well-implemented than my janky fix so now our track ui looks even better, especially on mobile. also, added a flex line to the box containing the album artwork and so now the size of the image remains uniform across changing screens sizes even if its for a track with a really long track name, which was a problem before.

i added in a genre variable to the form reducer so i could do a check to see if there was a genre selected coupled with a checked recommended checkbox and enable/disable the continue button depending on that value, so now you should be able to select the genre checkbox but will only be able to submit the form if there is a selected genre too.

i updated the results title for when a genre is picked by the user to actually show that genre instead of just saying "your recommended" since we don't explicitly say the genre select component is for recommendations. 

but the biggest, bestest change here is that i fixed the weird error we both had where the ui explodes after reloading; it was just a matter of adding a single line for styled-components in the babel config file :)