### PR TITLE
Resolve user transparency

### DIFF
--- a/components/results/results.spec.tsx
+++ b/components/results/results.spec.tsx
@@ -39,6 +39,7 @@ describe("<Results />", () => {
     it("renders without crashing", () => {
         shallow(
             <Results
+                selectedGenreValue={""}
                 tracks={mockTracks}
                 size={"large"}
                 mood={0}
@@ -49,9 +50,10 @@ describe("<Results />", () => {
         )
     })
 
-    it("does not render queue button if free user", () => {
-        const wrapper = render(
+    it("renders disabled queue button if free user", () => {
+        const wrapper = mount(
             <Results
+                selectedGenreValue={""}
                 size={"large"}
                 mood={Mood.SLEEPY}
                 tracks={mockTracks}
@@ -61,12 +63,13 @@ describe("<Results />", () => {
             />
         )
 
-        expect(wrapper.find("#play-queue-btn").length).to.be.eql(0)
+        expect(wrapper.find("#play-queue-btn").at(0).props().disabled).to.be.eql(true)
     })
 
     it("renders 'loading...' for number of tracks when tracks are loading", () => {
         const wrapper = render(
             <Results
+                selectedGenreValue={""}
                 size={"large"}
                 mood={Mood.SLEEPY}
                 tracks={mockTracks}
@@ -95,6 +98,7 @@ describe("<Results />", () => {
         const TestComponent = () => (
             <SpotifyProvider value={contextValues}>
                 <Results
+                    selectedGenreValue={""}
                     size={"large"}
                     mood={Mood.SLEEPY}
                     tracks={mockTracks}
@@ -126,6 +130,7 @@ describe("<Results />", () => {
     it("renders queue sources in description", () => {
         const wrapper = render(
             <Results
+                selectedGenreValue={""}
                 size={"large"}
                 mood={Mood.SLEEPY}
                 tracks={mockTracks}
@@ -153,6 +158,7 @@ describe("<Results />", () => {
         const TestComponent = () => (
             <SpotifyProvider value={contextValues}>
                 <Results
+                    selectedGenreValue={""}
                     size={"large"}
                     mood={Mood.SLEEPY}
                     tracks={mockTracks}
@@ -197,6 +203,7 @@ describe("<Results />", () => {
         const TestComponent = () => (
             <SpotifyProvider value={contextValues}>
                 <Results
+                    selectedGenreValue={""}
                     size={"large"}
                     mood={Mood.SLEEPY}
                     tracks={[]}
@@ -228,6 +235,7 @@ describe("<Results />", () => {
     it("renders play queue button", () => {
         const wrapper = render(
             <Results
+                selectedGenreValue={""}
                 size={"large"}
                 mood={Mood.SLEEPY}
                 tracks={mockTracks}
@@ -242,6 +250,7 @@ describe("<Results />", () => {
     it("renders start over button", () => {
         const wrapper = render(
             <Results
+                selectedGenreValue={""}
                 size={"large"}
                 mood={Mood.SLEEPY}
                 tracks={mockTracks}
@@ -270,6 +279,7 @@ describe("<Results />", () => {
         const TestComponent = () => (
             <SpotifyProvider value={contextValues}>
                 <Results
+                    selectedGenreValue={""}
                     size={"large"}
                     mood={Mood.SLEEPY}
                     tracks={mockTracks}
@@ -316,6 +326,7 @@ describe("<Results />", () => {
         const TestComponent = () => (
             <SpotifyProvider value={contextValues}>
                 <Results
+                    selectedGenreValue={""}
                     size={"large"}
                     mood={Mood.SLEEPY}
                     tracks={mockTracks}
@@ -362,6 +373,7 @@ describe("<Results />", () => {
         const TestComponent = () => (
             <SpotifyProvider value={contextValues}>
                 <Results
+                    selectedGenreValue={""}
                     size={"large"}
                     mood={Mood.SLEEPY}
                     tracks={mockTracks}

--- a/components/results/results.tsx
+++ b/components/results/results.tsx
@@ -139,12 +139,11 @@ export const Results: FunctionComponent<ResultsProps> = (props) => {
                                 <Button
                                     small
                                     id="play-queue-btn"
-                                    title="play your moodqueue"
                                     text="queue"
                                     icon={<CirclePlay color="dark-2" />}
                                     onClick={async () => {
-                                        let result = await addToQueue(state.tracks)
-                                        dispatch(update("showAfterParty", result))
+                                        await addToQueue(state.tracks)
+                                        resetForm()
                                     }}
                                 />
                             ) : (
@@ -154,7 +153,6 @@ export const Results: FunctionComponent<ResultsProps> = (props) => {
                                             disabled
                                             small
                                             id="play-queue-btn"
-                                            title="play your moodqueue"
                                             text="queue"
                                             icon={<CirclePlay color="dark-2" />}
                                         />
@@ -176,12 +174,11 @@ export const Results: FunctionComponent<ResultsProps> = (props) => {
                             <Button
                                 small
                                 id="playlist-btn"
-                                title="create a new moodqueue playlist or add to an existing one"
                                 text="playlist"
                                 icon={<Playlist width="24px" height="24px" />}
                                 onClick={async () => {
-                                    let result = await addToPlaylist(state.tracks)
-                                    dispatch(update("showAfterParty", result))
+                                    await addToPlaylist(state.tracks)
+                                    resetForm()
                                 }}
                                 secondary
                             />
@@ -189,7 +186,6 @@ export const Results: FunctionComponent<ResultsProps> = (props) => {
                         <Button
                             small
                             id="reset-btn"
-                            title="start over to begin a new moodqueue"
                             icon={<Previous color="light-2" />}
                             text="back"
                             onClick={resetForm}
@@ -205,8 +201,8 @@ export const Results: FunctionComponent<ResultsProps> = (props) => {
                                 text="add to queue"
                                 icon={<CirclePlay color="dark-2" />}
                                 onClick={async () => {
-                                    let result = await addToQueue(state.tracks)
-                                    dispatch(update("showAfterParty", result))
+                                    await addToQueue(state.tracks)
+                                    resetForm()
                                 }}
                             />
                         ) : (
@@ -236,8 +232,8 @@ export const Results: FunctionComponent<ResultsProps> = (props) => {
                             text="playlist"
                             icon={<Playlist width="26px" height="26px" />}
                             onClick={async () => {
-                                let result = await addToPlaylist(state.tracks)
-                                dispatch(update("showAfterParty", result))
+                                await addToPlaylist(state.tracks)
+                                resetForm()
                             }}
                             secondary
                         />

--- a/components/results/results.tsx
+++ b/components/results/results.tsx
@@ -164,7 +164,7 @@ export const Results: FunctionComponent<ResultsProps> = (props) => {
                                     >
                                         <Box width="small" align="center">
                                             <Description
-                                                text="unfortunately, this feature is reserved for spotify premium users only :("
+                                                text="unfortunately, this feature is limited to spotify premium users only :("
                                                 textAlign="center"
                                             />
                                         </Box>
@@ -211,7 +211,6 @@ export const Results: FunctionComponent<ResultsProps> = (props) => {
                                     <Button
                                         disabled
                                         id="play-queue-btn"
-                                        title="play your moodqueue"
                                         text="add to queue"
                                         icon={<CirclePlay color="dark-2" />}
                                     />
@@ -219,7 +218,7 @@ export const Results: FunctionComponent<ResultsProps> = (props) => {
                                 <ReactTooltip id="queue-tooltip">
                                     <Box width="small" align="center">
                                         <Description
-                                            text="unfortunately, this feature is reserved for spotify premium users only :("
+                                            text="unfortunately, this feature is limited to spotify premium users only :("
                                             textAlign="center"
                                         />
                                     </Box>

--- a/components/results/results.tsx
+++ b/components/results/results.tsx
@@ -22,6 +22,7 @@ import { motion } from "framer-motion"
 import { baseItemTop } from "../animations/motion"
 import { Button } from "../../ui/button/Button"
 import { Description } from "../../ui/description/Description"
+import ReactTooltip from "react-tooltip"
 
 interface ResultsProps {
     size: string
@@ -132,85 +133,111 @@ export const Results: FunctionComponent<ResultsProps> = (props) => {
                     )}
                 </Box>
                 {size === "small" ? (
-                    userProduct === "premium" ? (
-                        <Box align="center" gap="small">
-                            <Box direction="row" align="center" gap="medium">
+                    <Box align="center" gap="small">
+                        <Box direction="row" align="center" gap="medium">
+                            {userProduct === "premium" ? (
                                 <Button
                                     small
                                     id="play-queue-btn"
                                     title="play your moodqueue"
                                     text="queue"
                                     icon={<CirclePlay color="dark-2" />}
-                                    onClick={() => {
-                                        addToQueue(state.tracks)
+                                    onClick={async () => {
+                                        let result = await addToQueue(state.tracks)
+                                        dispatch(update("showAfterParty", result))
                                     }}
                                 />
-                                <Button
-                                    small
-                                    id="playlist-btn"
-                                    title="create a new moodqueue playlist"
-                                    text="playlist"
-                                    icon={<Playlist width="24px" height="24px" />}
-                                    onClick={() => {
-                                        addToPlaylist(state.tracks)
-                                    }}
-                                    secondary
-                                />
-                            </Box>
-                            <Button
-                                small
-                                id="reset-btn"
-                                title="start over to begin a new moodqueue"
-                                icon={<Previous color="light-2" />}
-                                text="back"
-                                onClick={resetForm}
-                                color="neutral-4"
-                            />
-                        </Box>
-                    ) : (
-                        <Box direction="row" align="center" gap="medium">
+                            ) : (
+                                <Box align="center">
+                                    <a data-for="queue-tooltip" data-tip data-event="click focus">
+                                        <Button
+                                            disabled
+                                            small
+                                            id="play-queue-btn"
+                                            title="play your moodqueue"
+                                            text="queue"
+                                            icon={<CirclePlay color="dark-2" />}
+                                        />
+                                    </a>
+                                    <ReactTooltip
+                                        id="queue-tooltip"
+                                        globalEventOff="click"
+                                        effect="solid"
+                                    >
+                                        <Box width="small" align="center">
+                                            <Description
+                                                text="unfortunately, this feature is reserved for spotify premium users only :("
+                                                textAlign="center"
+                                            />
+                                        </Box>
+                                    </ReactTooltip>
+                                </Box>
+                            )}
                             <Button
                                 small
                                 id="playlist-btn"
-                                title="create a new moodqueue playlist"
+                                title="create a new moodqueue playlist or add to an existing one"
                                 text="playlist"
                                 icon={<Playlist width="24px" height="24px" />}
-                                onClick={() => {
-                                    addToPlaylist(state.tracks)
+                                onClick={async () => {
+                                    let result = await addToPlaylist(state.tracks)
+                                    dispatch(update("showAfterParty", result))
                                 }}
                                 secondary
                             />
-                            <Button
-                                small
-                                id="reset-btn"
-                                title="start over to begin a new moodqueue"
-                                icon={<Previous color="light-2" />}
-                                text="back"
-                                onClick={resetForm}
-                                color="neutral-4"
-                            />
                         </Box>
-                    )
+                        <Button
+                            small
+                            id="reset-btn"
+                            title="start over to begin a new moodqueue"
+                            icon={<Previous color="light-2" />}
+                            text="back"
+                            onClick={resetForm}
+                            color="neutral-4"
+                        />
+                    </Box>
                 ) : (
                     <Box direction="row" align="center" gap="medium">
-                        {userProduct === "premium" && (
+                        {userProduct === "premium" ? (
                             <Button
                                 id="play-queue-btn"
                                 title="play your moodqueue"
                                 text="add to queue"
                                 icon={<CirclePlay color="dark-2" />}
-                                onClick={() => {
-                                    addToQueue(state.tracks)
+                                onClick={async () => {
+                                    let result = await addToQueue(state.tracks)
+                                    dispatch(update("showAfterParty", result))
                                 }}
                             />
+                        ) : (
+                            <Box align="center">
+                                <a data-for="queue-tooltip" data-tip>
+                                    <Button
+                                        disabled
+                                        id="play-queue-btn"
+                                        title="play your moodqueue"
+                                        text="add to queue"
+                                        icon={<CirclePlay color="dark-2" />}
+                                    />
+                                </a>
+                                <ReactTooltip id="queue-tooltip">
+                                    <Box width="small" align="center">
+                                        <Description
+                                            text="unfortunately, this feature is reserved for spotify premium users only :("
+                                            textAlign="center"
+                                        />
+                                    </Box>
+                                </ReactTooltip>
+                            </Box>
                         )}
                         <Button
                             id="playlist-btn"
-                            title="create a new moodqueue playlist"
-                            text="create playlist"
+                            title="create a new moodqueue playlist or add to an existing one"
+                            text="playlist"
                             icon={<Playlist width="26px" height="26px" />}
-                            onClick={() => {
-                                addToPlaylist(state.tracks)
+                            onClick={async () => {
+                                let result = await addToPlaylist(state.tracks)
+                                dispatch(update("showAfterParty", result))
                             }}
                             secondary
                         />

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "react-dom": "16.13.1",
     "react-is": "^16.13.1",
     "react-spinners": "^0.9.0",
+    "react-tooltip": "^4.2.10",
     "react-use-gesture": "^7.0.16",
     "styled-components": "^5.1.1",
     "styled-icons": "^10.19.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11297,6 +11297,14 @@ react-textarea-autosize@^8.1.1:
     use-composed-ref "^1.0.0"
     use-latest "^1.0.0"
 
+react-tooltip@^4.2.10:
+  version "4.2.10"
+  resolved "https://registry.yarnpkg.com/react-tooltip/-/react-tooltip-4.2.10.tgz#ed1a1acd388940c96f4b6309f4fd4dcce5e01bdc"
+  integrity sha512-D7ZLx6/QwpUl0SZRek3IZy/HWpsEEp0v3562tcT8IwZgu8IgV7hY5ZzniTkHyRcuL+IQnljpjj7A7zCgl2+T3w==
+  dependencies:
+    prop-types "^15.7.2"
+    uuid "^7.0.3"
+
 react-transition-group@^4.4.0:
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.1.tgz#63868f9325a38ea5ee9535d828327f85773345c9"
@@ -13278,6 +13286,11 @@ uuid@^3.1.0, uuid@^3.3.2:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
+
+uuid@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.3.tgz#c5c9f2c8cf25dc0a372c4df1441c41f5bd0c680b"
+  integrity sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==
 
 uuid@^8.3.0:
   version "8.3.1"


### PR DESCRIPTION
i accidentally added the tooltip to the other 'do not merge' branch im working on so i decided to kinda redo that aspect of that branch so we could have the tooltips in stage before i give the app off to jess again

i also made it so that form renders after the user presses either the queue or playlist button just so they aren't tempted to click them again or think that they can reorder/remove tracks in spotify through our app.

so yeah, thinking this should be the last thing added to master before giving it off to jess to review. i think we're pretty much done for sprint 5 and only really have the whole image thing left so this could be good time to let jess tear us apart.