### PR TITLE
add sentry to app to log feature usage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,4 @@ REACT_APP_REVIEW=moodqueue-.*?.herokuapp.com
 REACT_APP_STAGING=moodqueue-stage.herokuapp.com
 REACT_APP_PRODUCTION=moodqueue.herokuapp.com
 PORT=3000
+NEXT_PUBLIC_SENTRY_DSN=sentry-dsn-goes-here

--- a/common/hooks/useAuth.tsx
+++ b/common/hooks/useAuth.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import * as Sentry from "@sentry/browser"
 import { UserInfo } from "../../types/UserInfo"
 
 export interface AuthContextValue {
@@ -80,8 +81,8 @@ export const AuthProvider: React.FunctionComponent<AuthProviderProps> = (props) 
             profileUrl: data.external_urls.spotify,
             product: data.product,
         }
-
         setCurrentUser(newUser)
+        Sentry.captureMessage(`Login`)
     }
     const setAuthRedirect = (hostname: string) => {
         const regex = new RegExp(process.env.REVIEW_URL)

--- a/common/hooks/useSpotify.tsx
+++ b/common/hooks/useSpotify.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import * as Sentry from "@sentry/browser"
 import { useAuth } from "./useAuth"
 import { Track, PropertyTrack } from "../../types/Track"
 import { TrackSource } from "../../types/TrackSource"
@@ -74,7 +75,6 @@ export const SpotifyProvider: React.FunctionComponent<SpotifyProviderProps> = (p
                     return data.json()
                 })
                 .then((data) => {
-                    console.log(left, ":", right, ":", data.audio_features)
                     return combineTwoArraysOnId(tracks, data.audio_features)
                 })
             result.push(...temp)
@@ -162,6 +162,7 @@ export const SpotifyProvider: React.FunctionComponent<SpotifyProviderProps> = (p
     }
 
     const addSongsToPlaylist = async (uris: string, playlistId): Promise<void> => {
+        Sentry.captureMessage(`add to playlist`)
         try {
             return await fetch(
                 `https://api.spotify.com/v1/playlists/${playlistId}/tracks?uris=${uris}`,
@@ -204,9 +205,9 @@ export const SpotifyProvider: React.FunctionComponent<SpotifyProviderProps> = (p
         topGenres?: string[]
     ): Promise<Track[]> => {
         let tracks = []
-        console.log("TOP GENRES", topGenres)
 
         if (trackSource.includes(TrackSource.TOP_SONGS)) {
+            Sentry.captureMessage(`source includes top songs`)
             await spotifyHelper.getTopSongs(50).then(async (songs) => {
                 await getMultipleTracksAudioFeatures(songs).then((topTracks) => {
                     tracks = tracks.concat(topTracks)
@@ -214,6 +215,7 @@ export const SpotifyProvider: React.FunctionComponent<SpotifyProviderProps> = (p
             })
         }
         if (trackSource.includes(TrackSource.RECOMMENDED_SONGS)) {
+            Sentry.captureMessage(`source includes recommended songs`)
             await spotifyHelper.getRecommendedSongs(topGenres).then(async (songs) => {
                 await getMultipleTracksAudioFeatures(songs).then((recommendedTracks) => {
                     tracks = tracks.concat(recommendedTracks)
@@ -221,6 +223,7 @@ export const SpotifyProvider: React.FunctionComponent<SpotifyProviderProps> = (p
             })
         }
         if (trackSource.includes(TrackSource.TOP_ARTISTS_SONGS)) {
+            Sentry.captureMessage(`soure includes top artists`)
             await spotifyHelper.getTopArtistsTopSongs(50).then(async (songs) => {
                 await getMultipleTracksAudioFeatures(songs).then((topArtistsTracks) => {
                     tracks = tracks.concat(topArtistsTracks)
@@ -228,6 +231,7 @@ export const SpotifyProvider: React.FunctionComponent<SpotifyProviderProps> = (p
             })
         }
         if (trackSource.includes(TrackSource.SAVED_SONGS)) {
+            Sentry.captureMessage(`source includes saved songs`)
             await spotifyHelper.getSavedTracks(50).then(async (songs) => {
                 await getMultipleTracksAudioFeatures(songs).then((savedTracks) => {
                     tracks = tracks.concat(savedTracks)
@@ -238,14 +242,19 @@ export const SpotifyProvider: React.FunctionComponent<SpotifyProviderProps> = (p
         //as we add more moods, we will add more comparators
         let comparator
         if (mood === Mood.HAPPY) {
+            Sentry.captureMessage(`Mood: Happy`)
             comparator = happyComparator
         } else if (mood === Mood.SLEEPY) {
+            Sentry.captureMessage(`Mood: Sleepy`)
             comparator = sleepyComparator
         } else if (mood === Mood.PARTY) {
+            Sentry.captureMessage(`Mood: Party`)
             comparator = partyComparator
         } else if (mood === Mood.DRIVING) {
+            Sentry.captureMessage(`Mood: Driving`)
             comparator = drivingComparator
         } else {
+            Sentry.captureMessage(`Mood: Sad`)
             comparator = sadComparator
         }
         let trackSet = Array.from(new Set(tracks.map((o) => JSON.stringify(o)).values())).map((o) =>
@@ -260,6 +269,7 @@ export const SpotifyProvider: React.FunctionComponent<SpotifyProviderProps> = (p
     }
 
     const addToQueue = (tracks: Track[]): Promise<void | void[]> => {
+        Sentry.captureMessage(`add to queue`)
         return Promise.all(
             tracks.map((track) => {
                 addSongToQueue(track.uri)

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "dependencies": {
     "@material-ui/core": "^4.11.0",
+    "@sentry/browser": "^5.27.1",
     "@types/react-dom": "^16.9.8",
     "@types/styled-components": "^5.1.3",
     "chai": "^4.2.0",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,0 +1,12 @@
+import * as Sentry from "@sentry/browser"
+
+if (process.env.NEXT_PUBLIC_SENTRY_DSN) {
+    Sentry.init({
+        enabled: true, //process.env.NODE_ENV === 'production',
+        dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+    })
+}
+
+export default function App({ Component, pageProps, err }) {
+    return <Component {...pageProps} err={err} />
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1904,6 +1904,58 @@
   dependencies:
     any-observable "^0.3.0"
 
+"@sentry/browser@^5.27.1":
+  version "5.27.1"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-5.27.1.tgz#67da0cb9680ed54ecdb56a66abd8183b5a8ee174"
+  integrity sha512-OPBtKKJDgpJOJILaXntGp0z5KT2I1fmtePnHDdgPd7uNqXfTw0E6bvSjY9bR0pSJSooSwqZAAnsAZg8t4772ow==
+  dependencies:
+    "@sentry/core" "5.27.1"
+    "@sentry/types" "5.27.1"
+    "@sentry/utils" "5.27.1"
+    tslib "^1.9.3"
+
+"@sentry/core@5.27.1":
+  version "5.27.1"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-5.27.1.tgz#489604054d821e1de155f80fe650085b37cad235"
+  integrity sha512-n5CxzMbOAT6HZK4U4cOUAAikkRnnHhMNhInrjfZh7BoiuX1k63Hru2H5xk5WDuEaTTr5RaBA/fqPl7wxHySlwQ==
+  dependencies:
+    "@sentry/hub" "5.27.1"
+    "@sentry/minimal" "5.27.1"
+    "@sentry/types" "5.27.1"
+    "@sentry/utils" "5.27.1"
+    tslib "^1.9.3"
+
+"@sentry/hub@5.27.1":
+  version "5.27.1"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-5.27.1.tgz#c95faaf18257c365acc09246fafd27276bfd6a2f"
+  integrity sha512-RBHo3T92s6s4Ian1pZcPlmNtFqB+HAP6xitU+ZNA48bYUK+R1vvqEcI8Xs83FyNaRGCgclp9erDFQYyAuxY4vw==
+  dependencies:
+    "@sentry/types" "5.27.1"
+    "@sentry/utils" "5.27.1"
+    tslib "^1.9.3"
+
+"@sentry/minimal@5.27.1":
+  version "5.27.1"
+  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-5.27.1.tgz#d6ce881ba3c262db29520177a4c1f0e0f5388697"
+  integrity sha512-MHXCeJdA1NAvaJuippcM8nrWScul8iTN0Q5nnFkGctGIGmmiZHTXAYkObqJk7H3AK+CP7r1jqN2aQj5Nd9CtyA==
+  dependencies:
+    "@sentry/hub" "5.27.1"
+    "@sentry/types" "5.27.1"
+    tslib "^1.9.3"
+
+"@sentry/types@5.27.1":
+  version "5.27.1"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-5.27.1.tgz#031480a4cf8f0b6e6337fb03ee884deedcef6f40"
+  integrity sha512-g1aX0V0fz5BTo0mjgSVY9XmPLGZ6p+8OEzq3ubKzDUf59VHl+Vt8viZ8VXw/vsNtfAjBHn7BzSuzJo7cXJJBtA==
+
+"@sentry/utils@5.27.1":
+  version "5.27.1"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-5.27.1.tgz#0ed9d9685aae6f4ef9eb6b9ebb81e361fd1c5452"
+  integrity sha512-VIzK8utuvFO9EogZcKJPgmLnlJtYbaPQ0jCw7od9HRw1ckrSBc84sA0uuuY6pB6KSM+7k6EjJ5IdIBaCz5ep/A==
+  dependencies:
+    "@sentry/types" "5.27.1"
+    tslib "^1.9.3"
+
 "@sinonjs/commons@^1.7.0":
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.1.tgz#e7df00f98a203324f6dc7cc606cad9d4a8ab2217"
@@ -12985,6 +13037,11 @@ tslib@^1.10.0, tslib@^1.9.0:
   version "1.14.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.0.tgz#d624983f3e2c5e0b55307c3dd6c86acd737622c6"
   integrity sha512-+Zw5lu0D9tvBMjGP8LpvMb0u2WW2QV3y+D8mO6J+cNzCYIN4sVy43Bf9vl92nqFahutN0I8zHa7cc4vihIshnw==
+
+tslib@^1.9.3:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
+  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
 tslib@^2.0.0, tslib@^2.0.1:
   version "2.0.2"


### PR DESCRIPTION
I added sentry.io to the app so we can log feature usage to see which features are used most, which ones we could improve on, and view usage

Sentry also logs errors/exceptions

This is what the logs look like right now

![image](https://user-images.githubusercontent.com/31379789/97089499-f289ef80-15fc-11eb-998d-ba933434cf9e.png)

I added logging to 
- when someone successfully logs in
- the source type
- the mood type
- when add to queue
- when add to playlist

this should give us a good idea of how people are using the app and what they like about it

