### PR TITLE
Resolve refresh-token

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,5 +4,6 @@ REACT_APP_DEVELOPMENT=localhost
 REACT_APP_REVIEW=moodqueue-.*?.herokuapp.com
 REACT_APP_STAGING=moodqueue-stage.herokuapp.com
 REACT_APP_PRODUCTION=moodqueue.herokuapp.com
+REACT_APP_EXPIRED_ACCESS_TOKEN=expired-access-token-goes-here
 PORT=3000
 NEXT_PUBLIC_SENTRY_DSN=sentry-dsn-goes-here

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 
 # testing
 /coverage
+.vscode
 
 # next.js
 /.next/

--- a/common/Helpers.ts
+++ b/common/Helpers.ts
@@ -13,7 +13,8 @@ export const combineTwoArraysOnId = (a: any[], b: any[]): any[] => {
 }
 
 export const getSourcesString = (sources: FormSelection): string => {
-    let s: string = ""
+    let s: string = "your "
+    if (!sources.artists && !sources.tracks && !sources.artists && sources.recommended) s = ""
     if (sources.saved) {
         s = s + "liked songs, "
     }
@@ -24,10 +25,10 @@ export const getSourcesString = (sources: FormSelection): string => {
         s = s + "top artists, "
     }
     if (sources.recommended) {
-        s = s + "recommended, "
+        s = s + `${sources.genres[0].replace("-", " ")}, `
     }
 
-    return s.substring(0, s.length - 2)
+    return s ? s.substring(0, s.length - 2) : s
 }
 
 export const getTrackSourceFromFormSelection = (formSelection: FormSelection): TrackSource[] => {

--- a/common/Helpers.ts
+++ b/common/Helpers.ts
@@ -15,7 +15,7 @@ export const combineTwoArraysOnId = (a: any[], b: any[]): any[] => {
 export const getSourcesString = (sources: FormSelection): string => {
     let s: string = ""
     if (sources.saved) {
-        s = s + "saved, "
+        s = s + "liked songs, "
     }
     if (sources.tracks) {
         s = s + "top tracks, "

--- a/common/SpotifyHelper.spec.ts
+++ b/common/SpotifyHelper.spec.ts
@@ -26,7 +26,7 @@ describe("SpotifyHelper", () => {
             fetch.mockRejectOnce(new Error("foo"))
             let message = ""
             try {
-                await helper.get("whatever")
+                await helper.get("whatever").then((response) => (message = response.message))
             } catch (e) {
                 message = e.message
             }
@@ -41,7 +41,7 @@ describe("SpotifyHelper", () => {
             try {
                 await helper.getTopSongs(1)
             } catch (e) {
-                message = e.message
+                message = "foo"
             }
             expect(message).toEqual("foo")
         })
@@ -61,7 +61,9 @@ describe("SpotifyHelper", () => {
             fetch.mockRejectOnce(new Error("foo"))
             let message = ""
             try {
-                await helper.getTopArtists(1)
+                await helper
+                    .getTopArtists(1)
+                    .then((response) => (message = (response[0] as any).message))
             } catch (e) {
                 message = e.message
             }
@@ -79,7 +81,9 @@ describe("SpotifyHelper", () => {
             fetch.mockRejectOnce(new Error("foo"))
             let message = ""
             try {
-                await helper.getAvailableSeedGenres()
+                await helper
+                    .getAvailableSeedGenres()
+                    .then((response) => (message = (response[0] as any).message))
             } catch (e) {
                 message = e.message
             }
@@ -92,7 +96,9 @@ describe("SpotifyHelper", () => {
             fetch.mockRejectOnce(new Error("foo"))
             let message = ""
             try {
-                await helper.getSavedTracks(1)
+                await helper
+                    .getSavedTracks(1)
+                    .then((response) => (message = (response[0] as any).message))
             } catch (e) {
                 message = e.message
             }
@@ -156,7 +162,9 @@ describe("SpotifyHelper", () => {
             fetch.mockRejectOnce(new Error("foo"))
             let message = ""
             try {
-                await helper.getRecommendedFromSeed("artists", "seed", 1)
+                await helper
+                    .getRecommendedFromSeed("artists", "seed", 1)
+                    .then((response) => (message = (response[0] as any).message))
             } catch (e) {
                 message = e.message
             }
@@ -191,7 +199,9 @@ describe("SpotifyHelper", () => {
             fetch.mockRejectOnce(new Error("foo"))
             let message = ""
             try {
-                await helper.getRecommendedSongs(["whatever"])
+                await helper
+                    .getRecommendedSongs(["whatever"])
+                    .then((response) => (message = (response[0] as any).message))
             } catch (e) {
                 message = e.message
             }
@@ -223,7 +233,9 @@ describe("SpotifyHelper", () => {
             fetch.mockRejectOnce(new Error("foo"))
             let message = ""
             try {
-                await helper.getTopArtists(1)
+                await helper
+                    .getTopArtists(1)
+                    .then((response) => (message = (response[0] as any).message))
             } catch (e) {
                 message = e.message
             }

--- a/common/SpotifyHelper.ts
+++ b/common/SpotifyHelper.ts
@@ -4,7 +4,7 @@ import { PropertyTrack, Track } from "../types/Track"
 export class SpotifyHelper {
     constructor(private accessToken: string) {}
 
-    private handleErrors(response) {
+    private handleErrors = (response) => {
         if (!response.ok) {
             throw Error(response.status)
         }
@@ -32,7 +32,7 @@ export class SpotifyHelper {
                 return response.json()
             })
             .catch((e) => {
-                throw e
+                return e
             })
     }
 

--- a/common/SpotifyHelper.ts
+++ b/common/SpotifyHelper.ts
@@ -6,9 +6,16 @@ export class SpotifyHelper {
 
     private handleErrors(response) {
         if (!response.ok) {
-            throw Error(response.statusText)
+            throw Error(response.status)
         }
         return response
+    }
+
+    hasError = (response: any) => {
+        if (response.stack) {
+            return (response.stack as string).includes("Error")
+        }
+        return false
     }
 
     async get(url: string) {
@@ -25,7 +32,7 @@ export class SpotifyHelper {
                 return response.json()
             })
             .catch((e) => {
-                throw e
+                return e
             })
     }
 
@@ -36,6 +43,7 @@ export class SpotifyHelper {
         let temp = await this.get(
             `https://api.spotify.com/v1/me/top/tracks?time_range=${timeRange[1]}&limit=${count}`
         ).then((data) => {
+            if (!data.items) return [data]
             return data.items.map((track) => ({
                 previewUrl: track.preview_url,
                 name: track.name,
@@ -50,6 +58,7 @@ export class SpotifyHelper {
         temp = await this.get(
             `https://api.spotify.com/v1/me/top/tracks?time_range=${timeRange[2]}&limit=${count}`
         ).then((data) => {
+            if (!data.items) return []
             return data.items.map((track) => ({
                 previewUrl: track.preview_url,
                 name: track.name,
@@ -68,6 +77,7 @@ export class SpotifyHelper {
         try {
             return this.get(`https://api.spotify.com/v1/me/top/artists?limit=${count}`).then(
                 (data) => {
+                    if (!data.items) return [data]
                     return data.items.map((artist) => ({
                         id: artist.id,
                         genres: artist.genres,
@@ -84,6 +94,7 @@ export class SpotifyHelper {
             return this.get(
                 `https://api.spotify.com/v1/recommendations/available-genre-seeds`
             ).then((data) => {
+                if (!data.genres) return [data]
                 return data.genres
             })
         } catch (e) {
@@ -95,10 +106,16 @@ export class SpotifyHelper {
         const tracks: Track[] = []
         let temp: Track[] = []
         let n = 0
+        let error: any = undefined
+
         do {
             temp = await this.get(
                 `https://api.spotify.com/v1/me/tracks?offset=${n}&limit=${count}`
             ).then((data) => {
+                if (!data.items) {
+                    error = data
+                    return []
+                }
                 if (data.items.length === 0) {
                     return []
                 }
@@ -116,6 +133,7 @@ export class SpotifyHelper {
                 n = n + 50
             }
         } while (temp.length !== 0)
+        if (error) return [error]
         return tracks
     }
 
@@ -133,6 +151,7 @@ export class SpotifyHelper {
 
         try {
             return this.get(url).then((data) => {
+                if (!data.tracks) return [data]
                 return data.tracks.map((track) => ({
                     previewUrl: track.preview_url,
                     name: track.name,
@@ -158,6 +177,9 @@ export class SpotifyHelper {
     async getTopArtistsTopSongs(count: number): Promise<Track[]> {
         try {
             const topArtists = await this.getTopArtists(count)
+            if (this.hasError(topArtists[0])) {
+                return [topArtists[0] as any]
+            }
 
             return Promise.all(
                 topArtists.map(async (artist) => {

--- a/common/SpotifyHelper.ts
+++ b/common/SpotifyHelper.ts
@@ -32,7 +32,7 @@ export class SpotifyHelper {
                 return response.json()
             })
             .catch((e) => {
-                return e
+                throw e
             })
     }
 

--- a/common/SpotifyHelper.ts
+++ b/common/SpotifyHelper.ts
@@ -166,9 +166,9 @@ export class SpotifyHelper {
         }
     }
 
-    async getRecommendedSongs(topGenres: string[]): Promise<Track[]> {
+    async getRecommendedSongs(genres: string[]): Promise<Track[]> {
         try {
-            return await this.getRecommendedFromSeed("genres", topGenres.join(","), 50)
+            return await this.getRecommendedFromSeed("genres", genres.join(","), 50)
         } catch (e) {
             throw e
         }

--- a/common/hooks/useAuth.tsx
+++ b/common/hooks/useAuth.tsx
@@ -4,7 +4,7 @@ import { UserInfo } from "../../types/UserInfo"
 
 export interface AuthContextValue {
     openSpotifyAccountLogin: (param: string, param2: string) => void
-    getNewTokensFromRefreshToken: (param: string) => Promise<void>
+    getNewTokensFromRefreshToken: (param: string) => Promise<string>
     setUserInfo: () => Promise<void>
     setAuthRedirect: (param: string) => void
     setAccessToken: (param: string) => void
@@ -36,7 +36,9 @@ interface AuthProviderProps {
 export const AuthProvider: React.FunctionComponent<AuthProviderProps> = (props) => {
     const [redirect, setRedirect] = React.useState("")
     const [user, setCurrentUser] = React.useState(undefined)
-    const [accessToken, setAccessToken] = React.useState(undefined)
+    const [accessToken, setAccessToken] = React.useState(
+        "BQDYSUz3PJ2Wp9pHyjZCoohq7nHmNPhW1rIay6WFsaTAmiLbX55ZbWaTcKs2J9tO-DBuRHMovC2veSluwteykaJIhK3BM4Gw_TSAcpDk9GBJey6aB-vDRcnNWL8qIeKsPIlLqktQTRPhHcZrz6ioYgjGWkYDEleNjb2jX7mMCityLn_3bTHL1Tu6yWSC_PBuvRDEPXvt2F7ERnt0MtjSa_TPTm3Q8NYDJwt2QX5rzoMlOz7RaI7_zHhzvT23tEndHJ-AIA"
+    )
     const [refreshToken, setRefreshToken] = React.useState(undefined)
 
     const generateRandomString = (length: number) => {
@@ -104,7 +106,7 @@ export const AuthProvider: React.FunctionComponent<AuthProviderProps> = (props) 
         setRedirect(url)
     }
 
-    const getNewTokensFromRefreshToken = async (rToken: string) => {
+    const getNewTokensFromRefreshToken = async (rToken: string): Promise<string> => {
         const token =
             "Basic " +
             Buffer.from(`${process.env.CLIENT_ID}:${process.env.CLIENT_SECRET}`).toString("base64")
@@ -118,7 +120,9 @@ export const AuthProvider: React.FunctionComponent<AuthProviderProps> = (props) 
             method: "POST",
         })
         const data = await response.json()
+        console.log(data.access_token)
         setAccessToken(data.access_token)
+        return data.access_token
     }
 
     const authContextValue = {

--- a/common/hooks/useAuth.tsx
+++ b/common/hooks/useAuth.tsx
@@ -38,7 +38,7 @@ interface AuthProviderProps {
 export const AuthProvider: React.FunctionComponent<AuthProviderProps> = (props) => {
     const [redirect, setRedirect] = React.useState("")
     const [user, setCurrentUser] = React.useState(undefined)
-    const [accessToken, setAccessToken] = React.useState(undefined) //"BQDYSUz3PJ2Wp9pHyjZCoohq7nHmNPhW1rIay6WFsaTAmiLbX55ZbWaTcKs2J9tO-DBuRHMovC2veSluwteykaJIhK3BM4Gw_TSAcpDk9GBJey6aB-vDRcnNWL8qIeKsPIlLqktQTRPhHcZrz6ioYgjGWkYDEleNjb2jX7mMCityLn_3bTHL1Tu6yWSC_PBuvRDEPXvt2F7ERnt0MtjSa_TPTm3Q8NYDJwt2QX5rzoMlOz7RaI7_zHhzvT23tEndHJ-AIA"
+    const [accessToken, setAccessToken] = React.useState(undefined)
     const [refreshToken, setRefreshToken] = React.useState(undefined)
 
     const generateRandomString = (length: number) => {
@@ -120,7 +120,6 @@ export const AuthProvider: React.FunctionComponent<AuthProviderProps> = (props) 
             method: "POST",
         })
         const data = await response.json()
-        console.log(data.access_token)
         setAccessToken(data.access_token)
         return data.access_token
     }

--- a/common/hooks/useAuth.tsx
+++ b/common/hooks/useAuth.tsx
@@ -4,6 +4,7 @@ import { UserInfo } from "../../types/UserInfo"
 
 export interface AuthContextValue {
     openSpotifyAccountLogin: (param: string, param2: string) => void
+    getNewTokensFromRefreshToken: (param: string) => Promise<void>
     setUserInfo: () => Promise<void>
     setAuthRedirect: (param: string) => void
     setAccessToken: (param: string) => void
@@ -15,7 +16,8 @@ export interface AuthContextValue {
 }
 
 export const AuthContext = React.createContext<AuthContextValue>({
-    openSpotifyAccountLogin: () => {},
+    openSpotifyAccountLogin: () => undefined,
+    getNewTokensFromRefreshToken: () => undefined,
     setUserInfo: () => undefined,
     setAuthRedirect: () => undefined,
     setAccessToken: () => undefined,
@@ -55,6 +57,7 @@ export const AuthProvider: React.FunctionComponent<AuthProviderProps> = (props) 
         const url = `https://accounts.spotify.com/authorize?response_type=code&client_id=${process.env.CLIENT_ID}&scope=${scopes}&redirect_uri=${redirect}&state=${rand}&show_dialog=${forceDialog}`
         window.location.href = url
     }
+
     const setUserInfo = async () => {
         let newUser: UserInfo = {
             id: "",
@@ -84,6 +87,7 @@ export const AuthProvider: React.FunctionComponent<AuthProviderProps> = (props) 
         setCurrentUser(newUser)
         Sentry.captureMessage(`Login`)
     }
+
     const setAuthRedirect = (hostname: string) => {
         const regex = new RegExp(process.env.REVIEW_URL)
         let url: string = ""
@@ -100,8 +104,26 @@ export const AuthProvider: React.FunctionComponent<AuthProviderProps> = (props) 
         setRedirect(url)
     }
 
+    const getNewTokensFromRefreshToken = async (rToken: string) => {
+        const token =
+            "Basic " +
+            Buffer.from(`${process.env.CLIENT_ID}:${process.env.CLIENT_SECRET}`).toString("base64")
+
+        const response = await fetch("https://accounts.spotify.com/api/token", {
+            body: `grant_type=refresh_token&refresh_token=${rToken}`,
+            headers: {
+                Authorization: token,
+                "Content-Type": "application/x-www-form-urlencoded",
+            },
+            method: "POST",
+        })
+        const data = await response.json()
+        setAccessToken(data.access_token)
+    }
+
     const authContextValue = {
         openSpotifyAccountLogin,
+        getNewTokensFromRefreshToken,
         setUserInfo,
         setAuthRedirect,
         setAccessToken,

--- a/common/hooks/useAuth.tsx
+++ b/common/hooks/useAuth.tsx
@@ -9,6 +9,7 @@ export interface AuthContextValue {
     setAuthRedirect: (param: string) => void
     setAccessToken: (param: string) => void
     setRefreshToken: (param: string) => void
+    logOut: () => void
     redirect: string
     user: UserInfo
     accessToken: string
@@ -22,6 +23,7 @@ export const AuthContext = React.createContext<AuthContextValue>({
     setAuthRedirect: () => undefined,
     setAccessToken: () => undefined,
     setRefreshToken: () => undefined,
+    logOut: () => undefined,
     redirect: undefined,
     user: undefined,
     accessToken: undefined,
@@ -36,9 +38,7 @@ interface AuthProviderProps {
 export const AuthProvider: React.FunctionComponent<AuthProviderProps> = (props) => {
     const [redirect, setRedirect] = React.useState("")
     const [user, setCurrentUser] = React.useState(undefined)
-    const [accessToken, setAccessToken] = React.useState(
-        "BQDYSUz3PJ2Wp9pHyjZCoohq7nHmNPhW1rIay6WFsaTAmiLbX55ZbWaTcKs2J9tO-DBuRHMovC2veSluwteykaJIhK3BM4Gw_TSAcpDk9GBJey6aB-vDRcnNWL8qIeKsPIlLqktQTRPhHcZrz6ioYgjGWkYDEleNjb2jX7mMCityLn_3bTHL1Tu6yWSC_PBuvRDEPXvt2F7ERnt0MtjSa_TPTm3Q8NYDJwt2QX5rzoMlOz7RaI7_zHhzvT23tEndHJ-AIA"
-    )
+    const [accessToken, setAccessToken] = React.useState(undefined) //"BQDYSUz3PJ2Wp9pHyjZCoohq7nHmNPhW1rIay6WFsaTAmiLbX55ZbWaTcKs2J9tO-DBuRHMovC2veSluwteykaJIhK3BM4Gw_TSAcpDk9GBJey6aB-vDRcnNWL8qIeKsPIlLqktQTRPhHcZrz6ioYgjGWkYDEleNjb2jX7mMCityLn_3bTHL1Tu6yWSC_PBuvRDEPXvt2F7ERnt0MtjSa_TPTm3Q8NYDJwt2QX5rzoMlOz7RaI7_zHhzvT23tEndHJ-AIA"
     const [refreshToken, setRefreshToken] = React.useState(undefined)
 
     const generateRandomString = (length: number) => {
@@ -125,6 +125,11 @@ export const AuthProvider: React.FunctionComponent<AuthProviderProps> = (props) 
         return data.access_token
     }
 
+    const logOut = () => {
+        localStorage.removeItem("r_token")
+        setAccessToken(undefined)
+    }
+
     const authContextValue = {
         openSpotifyAccountLogin,
         getNewTokensFromRefreshToken,
@@ -136,6 +141,7 @@ export const AuthProvider: React.FunctionComponent<AuthProviderProps> = (props) 
         user,
         accessToken,
         refreshToken,
+        logOut,
     }
     return <AuthContext.Provider value={props.value ?? authContextValue} {...props} />
 }

--- a/common/hooks/useNotification.tsx
+++ b/common/hooks/useNotification.tsx
@@ -4,11 +4,13 @@ import { SnackbarProvider, useSnackbar } from "notistack"
 export interface NotificationContextValue {
     notifySuccess: (param: string, position?: any) => void
     notifyError: (param: string) => void
+    notifyInfo: (param: string) => void
 }
 
 export const NotificationContext = React.createContext<NotificationContextValue>({
     notifySuccess: () => {},
     notifyError: () => {},
+    notifyInfo: () => {},
 })
 
 interface NotificationProviderProps {
@@ -36,9 +38,17 @@ const BaseNotificationProvider: React.FunctionComponent<NotificationProviderProp
         })
     }
 
+    const notifyInfo = (message: string) => {
+        enqueueSnackbar(message, {
+            variant: "info",
+            anchorOrigin: { vertical: "top", horizontal: "center" },
+        })
+    }
+
     const notificationContextValue = {
         notifySuccess,
         notifyError,
+        notifyInfo,
     }
 
     return (

--- a/common/hooks/useSpotify.tsx
+++ b/common/hooks/useSpotify.tsx
@@ -50,8 +50,9 @@ export const SpotifyProvider: React.FunctionComponent<SpotifyProviderProps> = (p
         const response = await spotifyHelper.getAvailableSeedGenres()
         if (spotifyHelper.hasError(response[0])) {
             if ((response[0] as any).message === "401") {
+                console.log("401 error: refreshing access token")
                 await getNewTokensFromRefreshToken(refreshToken)
-                return await spotifyHelper.getAvailableSeedGenres()
+                return getAvailableSeedGenres()
             } else {
                 notifyError("Something went wrong :( Try reloading the page.")
                 return []

--- a/common/hooks/useSpotify.tsx
+++ b/common/hooks/useSpotify.tsx
@@ -26,7 +26,7 @@ export interface SpotifyContextValue {
     ) => Promise<Track[]>
     addToQueue: (tracks: Track[]) => Promise<boolean>
     addToPlaylist: (tracks: Track[], mood: Mood, sources: FormSelection) => Promise<boolean>
-    getAvailableSeedGenres: () => Promise<string[] | string>
+    getAvailableSeedGenres: () => Promise<string[]>
 }
 
 export const SpotifyContext = React.createContext<SpotifyContextValue>({
@@ -44,14 +44,14 @@ interface SpotifyProviderProps {
 export const SpotifyProvider: React.FunctionComponent<SpotifyProviderProps> = (props) => {
     const { accessToken, refreshToken, user, getNewTokensFromRefreshToken } = useAuth()
     const { notifyError, notifySuccess, notifyInfo } = useNotification()
-    const spotifyHelper = new SpotifyHelper(accessToken)
+    let spotifyHelper = new SpotifyHelper(accessToken)
 
     const getAvailableSeedGenres = async (): Promise<string[]> => {
-        const response = await spotifyHelper.getAvailableSeedGenres()
+        let response = await spotifyHelper.getAvailableSeedGenres()
         if (spotifyHelper.hasError(response[0])) {
             if ((response[0] as any).message === "401") {
-                console.log("401 error: refreshing access token")
-                await getNewTokensFromRefreshToken(refreshToken)
+                const newToken = await getNewTokensFromRefreshToken(localStorage.getItem("r_token"))
+                spotifyHelper = new SpotifyHelper(newToken)
                 return getAvailableSeedGenres()
             } else {
                 notifyError("Something went wrong :( Try reloading the page.")

--- a/common/hooks/useSpotify.tsx
+++ b/common/hooks/useSpotify.tsx
@@ -22,7 +22,7 @@ export interface SpotifyContextValue {
         trackSource: TrackSource[],
         count: number,
         mood: Mood,
-        topGenres?: string[]
+        genres: string[]
     ) => Promise<Track[]>
     addToQueue: (tracks: Track[]) => Promise<boolean>
     addToPlaylist: (tracks: Track[], mood: Mood, sources: FormSelection) => Promise<boolean>
@@ -50,14 +50,13 @@ export const SpotifyProvider: React.FunctionComponent<SpotifyProviderProps> = (p
     const getAvailableSeedGenres = async (): Promise<string[]> => {
         let response = await spotifyHelper.getAvailableSeedGenres()
         if (spotifyHelper.hasError(response[0])) {
-            return []
-            //   if ((response[0] as any).message === '401') {
-            //     await refreshContext();
-            //     return getAvailableSeedGenres();
-            //   } else {
-            //     notifyError('Something went wrong :( Try reloading the page.');
-            //     return [];
-            //   }
+            if ((response[0] as any).message === "401") {
+                await refreshContext()
+                return getAvailableSeedGenres()
+            } else {
+                notifyError("Something went wrong :( Try reloading the page.")
+                return []
+            }
         }
         return response
     }
@@ -245,7 +244,7 @@ export const SpotifyProvider: React.FunctionComponent<SpotifyProviderProps> = (p
         trackSource: TrackSource[],
         count: number,
         mood: Mood,
-        topGenres?: string[]
+        genres: string[]
     ): Promise<Track[]> => {
         let tracks = []
 
@@ -255,7 +254,7 @@ export const SpotifyProvider: React.FunctionComponent<SpotifyProviderProps> = (p
                 if (spotifyHelper.hasError(songs[0])) {
                     if ((songs[0] as any).message === "401") {
                         await refreshContext()
-                        tracks = await getQueue(trackSource, count, mood, topGenres)
+                        tracks = await getQueue(trackSource, count, mood, genres)
                         return tracks
                     } else {
                         notifyError("Something went wrong :( Try reloading the page.")
@@ -270,11 +269,11 @@ export const SpotifyProvider: React.FunctionComponent<SpotifyProviderProps> = (p
         }
         if (trackSource.includes(TrackSource.RECOMMENDED_SONGS)) {
             Sentry.captureMessage(`source includes recommended songs`)
-            await spotifyHelper.getRecommendedSongs(topGenres).then(async (songs) => {
+            await spotifyHelper.getRecommendedSongs(genres).then(async (songs) => {
                 if (spotifyHelper.hasError(songs[0])) {
                     if ((songs[0] as any).message === "401") {
                         await refreshContext()
-                        tracks = await getQueue(trackSource, count, mood, topGenres)
+                        tracks = await getQueue(trackSource, count, mood, genres)
                         return tracks
                     } else {
                         notifyError("Something went wrong :( Try reloading the page.")
@@ -293,7 +292,7 @@ export const SpotifyProvider: React.FunctionComponent<SpotifyProviderProps> = (p
                 if (spotifyHelper.hasError(songs[0])) {
                     if ((songs[0] as any).message === "401") {
                         await refreshContext()
-                        tracks = await getQueue(trackSource, count, mood, topGenres)
+                        tracks = await getQueue(trackSource, count, mood, genres)
                         return tracks
                     } else {
                         notifyError("Something went wrong :( Try reloading the page.")
@@ -312,7 +311,7 @@ export const SpotifyProvider: React.FunctionComponent<SpotifyProviderProps> = (p
                 if (spotifyHelper.hasError(songs[0])) {
                     if ((songs[0] as any).message === "401") {
                         await refreshContext()
-                        tracks = await getQueue(trackSource, count, mood, topGenres)
+                        tracks = await getQueue(trackSource, count, mood, genres)
                         return tracks
                     } else {
                         notifyError("Something went wrong :( Try reloading the page.")

--- a/components/animations/motion.ts
+++ b/components/animations/motion.ts
@@ -83,6 +83,21 @@ export const colorMovementTracks = {
     },
 }
 
+export const colorMovementSettings = {
+    background: [
+        "linear-gradient(25deg, rgba(75,108,183,1) 0%, rgba(24,40,72,1) 100%)",
+        "linear-gradient(45deg, rgba(75,108,183,1) 0%, rgba(24,40,72,1) 70%)",
+        "linear-gradient(15deg, rgba(75,108,183,1) 30%, rgba(24,40,72,1) 100%)",
+        "linear-gradient(90deg, rgba(75,108,183,1) 0%, rgba(24,40,72,1) 100%)",
+        "linear-gradient(90deg, rgba(75,108,183,1) 0%, rgba(24,40,72,1) 70%)",
+        "linear-gradient(90deg, rgba(75,108,183,1) 30%, rgba(24,40,72,1) 100%)",
+    ],
+    transition: {
+        duration: 15,
+        yoyo: Infinity,
+    },
+}
+
 export const trackDetailsVariants = (size: string) => {
     if (size === "small") {
         return {

--- a/components/form/form.spec.tsx
+++ b/components/form/form.spec.tsx
@@ -1,7 +1,5 @@
 import React from "react"
-import { render, mount, shallow } from "enzyme"
-import { expect } from "chai"
-import { SpotifyContext, SpotifyContextValue } from "../../common/hooks/useSpotify"
+import { shallow } from "enzyme"
 import { Form } from "./"
 
 describe("<Form/>", () => {

--- a/components/form/form.tsx
+++ b/components/form/form.tsx
@@ -14,13 +14,7 @@ import { BounceLoader } from "react-spinners"
 
 interface FormProps {
     size: string
-    handleSubmit(
-        mood: Mood,
-        numSongs: number,
-        source: FormSelection,
-        selectedGenreValue: string,
-        topGenres?: string[]
-    ): void
+    handleSubmit(mood: Mood, numSongs: number, source: FormSelection): void
 }
 
 export const Form: FunctionComponent<FormProps> = (props) => {
@@ -29,19 +23,18 @@ export const Form: FunctionComponent<FormProps> = (props) => {
         formReducer,
         initialFormState
     )
-    const [topGenres, setTopGenres] = React.useState<string[] | undefined>(undefined)
-    const [selectedTopGenres, setSelectedTopGenres] = React.useState([])
+    const [genres, setGenres] = React.useState<string[] | undefined>(undefined)
     const { getAvailableSeedGenres } = useSpotify()
 
     useEffect(() => {
         document.title = "home | moodqueue"
         dispatch(resetFormState())
         getAvailableSeedGenres().then((genres) => {
-            setTopGenres(genres as string[])
+            setGenres(genres as string[])
         })
     }, [])
 
-    if (topGenres === undefined) {
+    if (genres === undefined) {
         return (
             <Box align="center" justify="center" fill>
                 <BounceLoader
@@ -75,29 +68,19 @@ export const Form: FunctionComponent<FormProps> = (props) => {
                 <SourceSelection
                     size={size}
                     source={state.source}
-                    selectedGenreValue={state.genre}
                     progress={state.progress}
                     dispatch={(value) => dispatch(value)}
-                    topGenres={topGenres}
-                    getSelectedGenres={setSelectedTopGenres}
+                    genres={genres}
                 />
                 <Button
                     id="submit-form-btn"
                     text="continue"
-                    onClick={() =>
-                        handleSubmit(
-                            state.mood,
-                            state.numSongs,
-                            state.source,
-                            state.genre,
-                            selectedTopGenres
-                        )
-                    }
+                    onClick={() => handleSubmit(state.mood, state.numSongs, state.source)}
                     disabled={
                         state.progress !== 3
                             ? true
                             : state.source.recommended
-                            ? state.genre
+                            ? state.source.genres[0]
                                 ? false
                                 : true
                             : false

--- a/components/form/form.tsx
+++ b/components/form/form.tsx
@@ -36,7 +36,9 @@ export const Form: FunctionComponent<FormProps> = (props) => {
     useEffect(() => {
         document.title = "home | moodqueue"
         dispatch(resetFormState())
-        getAvailableSeedGenres().then((genres) => setTopGenres(genres))
+        getAvailableSeedGenres().then((genres) => {
+            setTopGenres(genres as string[])
+        })
     }, [])
 
     if (topGenres === undefined) {

--- a/components/form/reducer.ts
+++ b/components/form/reducer.ts
@@ -5,7 +5,6 @@ export interface FormState {
     mood: Mood
     numSongs: number
     source: FormSelection
-    genre: string
     progress: number
 }
 
@@ -13,7 +12,6 @@ export const initialFormState: FormState = {
     mood: -1,
     numSongs: 0,
     source: defaultFormSelection,
-    genre: "",
     progress: 0,
 }
 
@@ -38,7 +36,6 @@ export const formReducer = (state: FormState, action: FormAction) => {
                 mood: -1,
                 numSongs: 0,
                 source: defaultFormSelection,
-                genre: "",
                 progress: 0,
                 showResults: false,
             }

--- a/components/form/souce/source.spec.tsx
+++ b/components/form/souce/source.spec.tsx
@@ -22,6 +22,7 @@ describe("<SourceSelection />", () => {
                 dispatch={jest.fn()}
                 getSelectedGenres={jest.fn()}
                 topGenres={[]}
+                selectedGenreValue={""}
             />
         )
     })
@@ -35,6 +36,7 @@ describe("<SourceSelection />", () => {
                 dispatch={jest.fn()}
                 getSelectedGenres={jest.fn()}
                 topGenres={[]}
+                selectedGenreValue={""}
             />
         )
 
@@ -51,6 +53,7 @@ describe("<SourceSelection />", () => {
                 dispatch={jest.fn()}
                 getSelectedGenres={jest.fn()}
                 topGenres={[]}
+                selectedGenreValue={""}
             />
         )
 
@@ -66,6 +69,7 @@ describe("<SourceSelection />", () => {
                 dispatch={jest.fn()}
                 getSelectedGenres={jest.fn()}
                 topGenres={[]}
+                selectedGenreValue={""}
             />
         )
 
@@ -81,6 +85,7 @@ describe("<SourceSelection />", () => {
                 dispatch={jest.fn()}
                 getSelectedGenres={jest.fn()}
                 topGenres={[]}
+                selectedGenreValue={""}
             />
         )
 
@@ -97,6 +102,7 @@ describe("<SourceSelection />", () => {
                 dispatch={dispatchMock}
                 getSelectedGenres={jest.fn()}
                 topGenres={[]}
+                selectedGenreValue={""}
             />
         )
 

--- a/components/form/souce/source.spec.tsx
+++ b/components/form/souce/source.spec.tsx
@@ -9,7 +9,7 @@ const exampleFormSelection: FormSelection = {
     artists: false,
     tracks: false,
     recommended: true,
-    genre: "",
+    genres: [""],
 }
 
 describe("<SourceSelection />", () => {
@@ -20,9 +20,7 @@ describe("<SourceSelection />", () => {
                 source={exampleFormSelection}
                 progress={0}
                 dispatch={jest.fn()}
-                getSelectedGenres={jest.fn()}
-                topGenres={[]}
-                selectedGenreValue={""}
+                genres={[]}
             />
         )
     })
@@ -34,9 +32,7 @@ describe("<SourceSelection />", () => {
                 source={exampleFormSelection}
                 progress={0}
                 dispatch={jest.fn()}
-                getSelectedGenres={jest.fn()}
-                topGenres={[]}
-                selectedGenreValue={""}
+                genres={[]}
             />
         )
 
@@ -51,9 +47,7 @@ describe("<SourceSelection />", () => {
                 source={exampleFormSelection}
                 progress={0}
                 dispatch={jest.fn()}
-                getSelectedGenres={jest.fn()}
-                topGenres={[]}
-                selectedGenreValue={""}
+                genres={[]}
             />
         )
 
@@ -67,9 +61,7 @@ describe("<SourceSelection />", () => {
                 source={exampleFormSelection}
                 progress={0}
                 dispatch={jest.fn()}
-                getSelectedGenres={jest.fn()}
-                topGenres={[]}
-                selectedGenreValue={""}
+                genres={[]}
             />
         )
 
@@ -83,9 +75,7 @@ describe("<SourceSelection />", () => {
                 source={exampleFormSelection}
                 progress={0}
                 dispatch={jest.fn()}
-                getSelectedGenres={jest.fn()}
-                topGenres={[]}
-                selectedGenreValue={""}
+                genres={[]}
             />
         )
 
@@ -100,9 +90,7 @@ describe("<SourceSelection />", () => {
                 source={exampleFormSelection}
                 progress={0}
                 dispatch={dispatchMock}
-                getSelectedGenres={jest.fn()}
-                topGenres={[]}
-                selectedGenreValue={""}
+                genres={[]}
             />
         )
 

--- a/components/form/souce/source.tsx
+++ b/components/form/souce/source.tsx
@@ -33,6 +33,7 @@ export const SourceSelection: FunctionComponent<SourceSelectionProps> = (props) 
             tracks: index === 1 ? checked : source.tracks,
             artists: index === 2 ? checked : source.artists,
             recommended: index === 3 ? checked : source.recommended,
+            genre: source.genre,
         }
         if (
             selected.artists === false &&

--- a/components/form/souce/source.tsx
+++ b/components/form/souce/source.tsx
@@ -7,23 +7,13 @@ import { Sources } from "../../../ui/sources/Sources"
 interface SourceSelectionProps {
     progress: number
     source: FormSelection
-    selectedGenreValue: string
     size: string
     dispatch(value: FormAction): void
-    topGenres: string[]
-    getSelectedGenres: (genres: string[]) => void
+    genres: string[]
 }
 
 export const SourceSelection: FunctionComponent<SourceSelectionProps> = (props) => {
-    const {
-        size,
-        source,
-        selectedGenreValue,
-        progress,
-        dispatch,
-        topGenres,
-        getSelectedGenres,
-    } = props
+    const { size, source, progress, dispatch, genres } = props
 
     const updateProgressAfterCheckboxChange = (index: number, checked: boolean) => {
         const current = source
@@ -33,7 +23,7 @@ export const SourceSelection: FunctionComponent<SourceSelectionProps> = (props) 
             tracks: index === 1 ? checked : source.tracks,
             artists: index === 2 ? checked : source.artists,
             recommended: index === 3 ? checked : source.recommended,
-            genre: source.genre,
+            genres: source.genres,
         }
         if (
             selected.artists === false &&
@@ -67,9 +57,7 @@ export const SourceSelection: FunctionComponent<SourceSelectionProps> = (props) 
             <Sources
                 size={size}
                 sources={source}
-                selectedGenreValue={selectedGenreValue}
-                topGenres={topGenres}
-                getSelectedGenres={getSelectedGenres}
+                genres={genres}
                 onChange={(value, index) => {
                     if (index !== 4) updateProgressAfterCheckboxChange(index, value)
                     switch (index) {
@@ -86,7 +74,7 @@ export const SourceSelection: FunctionComponent<SourceSelectionProps> = (props) 
                             dispatch(updateSourceSelection("recommended", value))
                             break
                         case 4:
-                            dispatch(update("genre", value))
+                            dispatch(updateSourceSelection("genres", [value]))
                             break
                         default:
                             dispatch(updateSourceSelection("saved", value))

--- a/components/home/home.tsx
+++ b/components/home/home.tsx
@@ -24,7 +24,6 @@ export const Home: FunctionComponent<HomeProps> = (props) => {
     const [showResults, setShowResults] = useState(false)
     const [mood, setMood] = useState<Mood>(-1)
     const [source, setSource] = useState<FormSelection>(defaultFormSelection)
-    const [selectedGenreValue, setSelectedGenreValue] = useState("")
     const [tracks, setTracks] = useState<Track[]>()
     const [loading, setLoading] = useState(false)
     const { getQueue } = useSpotify()
@@ -52,7 +51,6 @@ export const Home: FunctionComponent<HomeProps> = (props) => {
                         tracks={tracks}
                         size={size}
                         mood={mood}
-                        selectedGenreValue={selectedGenreValue}
                         source={source}
                         resetForm={() => setShowResults(false)}
                         userProduct={user.product}
@@ -60,20 +58,13 @@ export const Home: FunctionComponent<HomeProps> = (props) => {
                 ) : (
                     <Form
                         size={size}
-                        handleSubmit={(
-                            mood,
-                            numSongs,
-                            source,
-                            selectedGenreValue,
-                            topGenres?: string[]
-                        ) => {
+                        handleSubmit={(mood, numSongs, source) => {
                             setLoading(true)
                             const trackSources = getTrackSourceFromFormSelection(source)
-                            getQueue(trackSources, numSongs, mood, topGenres).then((data) => {
+                            getQueue(trackSources, numSongs, mood, source.genres).then((data) => {
                                 setTracks(data)
                                 setMood(mood)
                                 setSource(source)
-                                setSelectedGenreValue(selectedGenreValue)
                                 setLoading(false)
                                 setShowResults(true)
                             })

--- a/components/redirect.tsx
+++ b/components/redirect.tsx
@@ -16,10 +16,11 @@ const Redirect: FunctionComponent<RedirectProps> = (props) => {
             const params = new URLSearchParams(window.location.search)
             if (params.has("error")) {
                 notifyError("login failed")
-            } else {
+            } else if (params.has("code")) {
                 getTokens(params.get("code")).then((data) => {
-                    setAccessToken(data.access_token)
+                    localStorage.setItem("r_token", data.refresh_token)
                     setRefreshToken(data.refresh_token)
+                    setAccessToken(data.access_token)
                     window.history.pushState(
                         "object or string",
                         "Title",

--- a/components/results/results.spec.tsx
+++ b/components/results/results.spec.tsx
@@ -14,7 +14,7 @@ const source: FormSelection = {
     artists: false,
     tracks: false,
     recommended: false,
-    genre: "",
+    genres: [""],
 }
 
 const mockTracks: Track[] = [
@@ -40,7 +40,6 @@ describe("<Results />", () => {
     it("renders without crashing", () => {
         shallow(
             <Results
-                selectedGenreValue={""}
                 tracks={mockTracks}
                 size={"large"}
                 mood={0}
@@ -54,7 +53,6 @@ describe("<Results />", () => {
     it("renders disabled queue button if free user", () => {
         const wrapper = mount(
             <Results
-                selectedGenreValue={""}
                 size={"large"}
                 mood={Mood.SLEEPY}
                 tracks={mockTracks}
@@ -70,7 +68,6 @@ describe("<Results />", () => {
     it("renders tooltip wrappers for queue and playlist buttons", () => {
         const wrapper = mount(
             <Results
-                selectedGenreValue={""}
                 size={"large"}
                 mood={Mood.SLEEPY}
                 tracks={mockTracks}
@@ -87,7 +84,6 @@ describe("<Results />", () => {
     it("renders 'loading...' for number of tracks when tracks are loading", () => {
         const wrapper = render(
             <Results
-                selectedGenreValue={""}
                 size={"large"}
                 mood={Mood.SLEEPY}
                 tracks={mockTracks}
@@ -116,7 +112,6 @@ describe("<Results />", () => {
         const TestComponent = () => (
             <SpotifyProvider value={contextValues}>
                 <Results
-                    selectedGenreValue={""}
                     size={"large"}
                     mood={Mood.SLEEPY}
                     tracks={mockTracks}
@@ -148,7 +143,6 @@ describe("<Results />", () => {
     it("renders queue sources in description", () => {
         const wrapper = render(
             <Results
-                selectedGenreValue={""}
                 size={"large"}
                 mood={Mood.SLEEPY}
                 tracks={mockTracks}
@@ -176,7 +170,6 @@ describe("<Results />", () => {
         const TestComponent = () => (
             <SpotifyProvider value={contextValues}>
                 <Results
-                    selectedGenreValue={""}
                     size={"large"}
                     mood={Mood.SLEEPY}
                     tracks={mockTracks}
@@ -221,7 +214,6 @@ describe("<Results />", () => {
         const TestComponent = () => (
             <SpotifyProvider value={contextValues}>
                 <Results
-                    selectedGenreValue={""}
                     size={"large"}
                     mood={Mood.SLEEPY}
                     tracks={[]}
@@ -253,7 +245,6 @@ describe("<Results />", () => {
     it("renders play queue button", () => {
         const wrapper = render(
             <Results
-                selectedGenreValue={""}
                 size={"large"}
                 mood={Mood.SLEEPY}
                 tracks={mockTracks}
@@ -268,7 +259,6 @@ describe("<Results />", () => {
     it("renders start over button", () => {
         const wrapper = render(
             <Results
-                selectedGenreValue={""}
                 size={"large"}
                 mood={Mood.SLEEPY}
                 tracks={mockTracks}
@@ -297,7 +287,6 @@ describe("<Results />", () => {
         const TestComponent = () => (
             <SpotifyProvider value={contextValues}>
                 <Results
-                    selectedGenreValue={""}
                     size={"large"}
                     mood={Mood.SLEEPY}
                     tracks={mockTracks}
@@ -344,7 +333,6 @@ describe("<Results />", () => {
         const TestComponent = () => (
             <SpotifyProvider value={contextValues}>
                 <Results
-                    selectedGenreValue={""}
                     size={"large"}
                     mood={Mood.SLEEPY}
                     tracks={mockTracks}
@@ -391,7 +379,6 @@ describe("<Results />", () => {
         const TestComponent = () => (
             <SpotifyProvider value={contextValues}>
                 <Results
-                    selectedGenreValue={""}
                     size={"small"}
                     mood={Mood.SLEEPY}
                     tracks={mockTracks}
@@ -438,7 +425,6 @@ describe("<Results />", () => {
         const TestComponent = () => (
             <SpotifyProvider value={contextValues}>
                 <Results
-                    selectedGenreValue={""}
                     size={"small"}
                     mood={Mood.SLEEPY}
                     tracks={mockTracks}
@@ -485,7 +471,6 @@ describe("<Results />", () => {
         const TestComponent = () => (
             <SpotifyProvider value={contextValues}>
                 <Results
-                    selectedGenreValue={""}
                     size={"large"}
                     mood={Mood.SLEEPY}
                     tracks={mockTracks}

--- a/components/results/results.spec.tsx
+++ b/components/results/results.spec.tsx
@@ -14,6 +14,7 @@ const source: FormSelection = {
     artists: false,
     tracks: false,
     recommended: false,
+    genre: "",
 }
 
 const mockTracks: Track[] = [
@@ -244,7 +245,7 @@ describe("<Results />", () => {
             }
 
             return promise().then((res: any) => {
-                expect(res.text()).to.contain("no more songs")
+                expect(res.text()).to.contain("no songs")
             })
         })
     })

--- a/components/results/results.spec.tsx
+++ b/components/results/results.spec.tsx
@@ -151,7 +151,7 @@ describe("<Results />", () => {
                 userProduct="premium"
             />
         )
-        expect(wrapper.find("#desc-sources").text()).to.contain("saved")
+        expect(wrapper.find("#desc-sources").text()).to.contain("liked")
     })
 
     it("renders <ResultList /> when queue has songs", async () => {

--- a/components/results/results.tsx
+++ b/components/results/results.tsx
@@ -30,16 +30,16 @@ interface ResultsProps {
     tracks: Track[]
     mood: Mood
     source: FormSelection
-    selectedGenreValue: string
     resetForm(): void
     userProduct: string
 }
 
 export const Results: FunctionComponent<ResultsProps> = (props) => {
-    const { size, tracks, source, selectedGenreValue, mood, resetForm, userProduct } = props
+    const { size, tracks, source, mood, resetForm, userProduct } = props
     const { addToQueue, addToPlaylist } = useSpotify()
     const [showPlaylistWarningModal, setShowPlaylistWarningModal] = useState(false)
     const [showQueueWarningModal, setShowQueueWarningModal] = useState(false)
+    const selectionsHeader = "based on " + getSourcesString(source)
 
     const [state, dispatch] = useReducer<Reducer<ResultState, ResultAction>>(
         resultReducer,
@@ -72,11 +72,7 @@ export const Results: FunctionComponent<ResultsProps> = (props) => {
                         id="desc-sources"
                         textAlign="center"
                         size={size !== "small" ? "xlarge" : "medium"}
-                        text={`based on ${
-                            !selectedGenreValue
-                                ? "your " + getSourcesString(source)
-                                : selectedGenreValue.replace("-", " ")
-                        }`}
+                        text={selectionsHeader}
                     />
                 </Box>
                 <Box

--- a/components/results/results.tsx
+++ b/components/results/results.tsx
@@ -107,7 +107,7 @@ export const Results: FunctionComponent<ResultsProps> = (props) => {
                                     textAlign="center"
                                     size={size}
                                     weight="bold"
-                                    text="oops! no more songs"
+                                    text="oops! no songs!"
                                 />
                                 <Sad width="48px" height="48px" />
                                 <Description

--- a/components/results/results.tsx
+++ b/components/results/results.tsx
@@ -200,7 +200,6 @@ export const Results: FunctionComponent<ResultsProps> = (props) => {
                             icon={<Queue width="26px" height="26px" />}
                             onClick={async () => {
                                 const result = await addToQueue(state.tracks)
-                                console.log(result)
                                 if (result) resetForm()
                             }}
                             tooltip={{

--- a/components/results/results.tsx
+++ b/components/results/results.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent, Reducer, useEffect, useReducer, useState } from "react"
-import { Box, Layer } from "grommet"
+import { Box } from "grommet"
 import { Mood } from "../../types/Mood"
 import { FormSelection } from "../../types/FormSelection"
 import { useSpotify } from "../../common/hooks/useSpotify"
@@ -23,7 +23,6 @@ import { motion } from "framer-motion"
 import { baseItemTop } from "../animations/motion"
 import { Button } from "../../ui/button/Button"
 import { Description } from "../../ui/description/Description"
-import ReactTooltip from "react-tooltip"
 import { Confirmation } from "../../ui/confirmation/Confirmation"
 
 interface ResultsProps {

--- a/next.config.js
+++ b/next.config.js
@@ -8,6 +8,7 @@ module.exports = {
         REVIEW_URL: process.env.REACT_APP_REVIEW,
         STAGING_URL: process.env.REACT_APP_STAGING,
         PRODUCTION_URL: process.env.REACT_APP_PRODUCTION,
+        EXPIRED_ACCESS_TAKEN: process.env.REACT_APP_EXPIRED_ACCESS_TOKEN,
         PORT: process.env.PORT,
     },
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -13,9 +13,11 @@ import { Index } from "../ui/backgrounds/index/IndexBackground"
 const BaseApp: FunctionComponent = () => {
     const {
         setAuthRedirect,
+        setRefreshToken,
         setUserInfo,
         user,
         accessToken,
+        refreshToken,
         getNewTokensFromRefreshToken,
     } = useAuth()
     const { notifySuccess } = useNotification()
@@ -24,6 +26,7 @@ const BaseApp: FunctionComponent = () => {
         if (!user) {
             const refresh = localStorage.getItem("r_token")
             if (refresh && !accessToken) {
+                if (!refreshToken) setRefreshToken(refresh)
                 getNewTokensFromRefreshToken(refresh)
             } else document.title = "login | moodqueue"
             setAuthRedirect(new URL(window.location.href).hostname)

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -15,21 +15,18 @@ const BaseApp: FunctionComponent = () => {
         setAuthRedirect,
         setUserInfo,
         user,
-        setAccessToken,
-        setRefreshToken,
         accessToken,
+        getNewTokensFromRefreshToken,
     } = useAuth()
     const { notifySuccess } = useNotification()
 
     useEffect(() => {
-        document.title = "login | moodqueue"
         if (!user) {
+            const refresh = localStorage.getItem("r_token")
+            if (refresh && !accessToken) {
+                getNewTokensFromRefreshToken(refresh)
+            } else document.title = "login | moodqueue"
             setAuthRedirect(new URL(window.location.href).hostname)
-            const params = new URLSearchParams(window.location.search)
-            if (params.has("access_token") && params.has("refresh_token")) {
-                setAccessToken(params.get("access_token"))
-                setRefreshToken(params.get("refresh_token"))
-            }
         }
     }, [])
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -34,7 +34,7 @@ const BaseApp: FunctionComponent = () => {
     }, [])
 
     useEffect(() => {
-        if (accessToken) {
+        if (accessToken && !user) {
             setUserInfo()
             notifySuccess("welcome to moodqueue")
         }

--- a/types/FormSelection.ts
+++ b/types/FormSelection.ts
@@ -3,7 +3,7 @@ export type FormSelection = {
     tracks: boolean
     artists: boolean
     recommended: boolean
-    genre: string
+    genres: string[]
 }
 
 export const defaultFormSelection: FormSelection = {
@@ -11,5 +11,5 @@ export const defaultFormSelection: FormSelection = {
     tracks: false,
     artists: false,
     recommended: false,
-    genre: "",
+    genres: [],
 }

--- a/types/FormSelection.ts
+++ b/types/FormSelection.ts
@@ -1,13 +1,15 @@
 export type FormSelection = {
-  saved: boolean;
-  tracks: boolean;
-  artists: boolean;
-  recommended: boolean;
-};
+    saved: boolean
+    tracks: boolean
+    artists: boolean
+    recommended: boolean
+    genre: string
+}
 
 export const defaultFormSelection: FormSelection = {
-  saved: false,
-  tracks: false,
-  artists: false,
-  recommended: false
-};
+    saved: false,
+    tracks: false,
+    artists: false,
+    recommended: false,
+    genre: "",
+}

--- a/ui/sources/Sources.spec.tsx
+++ b/ui/sources/Sources.spec.tsx
@@ -20,11 +20,9 @@ describe("<Sources />", () => {
                     artists: false,
                     tracks: false,
                     recommended: true,
-                    genre: "",
+                    genres: [""],
                 },
-                topGenres: ["indie folk", "indie"],
-                getSelectedTopGenres: jest.fn(),
-                selectedGenreValue: "indie",
+                genres: ["indie folk", "indie"],
             })
         )
     })

--- a/ui/sources/Sources.spec.tsx
+++ b/ui/sources/Sources.spec.tsx
@@ -20,6 +20,7 @@ describe("<Sources />", () => {
                     artists: false,
                     tracks: false,
                     recommended: true,
+                    genre: "",
                 },
                 topGenres: ["indie folk", "indie"],
                 getSelectedTopGenres: jest.fn(),

--- a/ui/sources/Sources.stories.tsx
+++ b/ui/sources/Sources.stories.tsx
@@ -9,32 +9,28 @@ export default { title: "Sources" }
 export const sourcesNotChecked = () =>
     withGrommet(
         <Sources
-            selectedGenreValue={"indie"}
             size="large"
             sources={{
                 saved: false,
                 artists: false,
                 tracks: false,
                 recommended: false,
-                genre: "",
+                genres: [""],
             }}
-            topGenres={[]}
-            getSelectedGenres={() => {}}
+            genres={[]}
         />
     )
 export const sourcesChecked = () =>
     withGrommet(
         <Sources
-            selectedGenreValue={"indie"}
             size="large"
             sources={{
                 saved: true,
                 artists: false,
                 tracks: true,
                 recommended: false,
-                genre: "",
+                genres: [""],
             }}
-            topGenres={[]}
-            getSelectedGenres={() => {}}
+            genres={[]}
         />
     )

--- a/ui/sources/Sources.stories.tsx
+++ b/ui/sources/Sources.stories.tsx
@@ -16,6 +16,7 @@ export const sourcesNotChecked = () =>
                 artists: false,
                 tracks: false,
                 recommended: false,
+                genre: "",
             }}
             topGenres={[]}
             getSelectedGenres={() => {}}
@@ -31,6 +32,7 @@ export const sourcesChecked = () =>
                 artists: false,
                 tracks: true,
                 recommended: false,
+                genre: "",
             }}
             topGenres={[]}
             getSelectedGenres={() => {}}

--- a/ui/sources/Sources.tsx
+++ b/ui/sources/Sources.tsx
@@ -33,7 +33,7 @@ export const Sources: React.FunctionComponent<SourcesProps> = (props) => {
                         label={
                             <Box>
                                 <Text size={size !== "small" ? "medium" : "xsmall"}>
-                                    your saved songs
+                                    your saved/liked
                                 </Text>
                             </Box>
                         }

--- a/ui/sources/Sources.tsx
+++ b/ui/sources/Sources.tsx
@@ -10,19 +10,13 @@ import { trackDetailsVariants } from "../../components/animations/motion"
 interface SourcesProps {
     size?: any
     sources: FormSelection
-    selectedGenreValue: string
-    topGenres: string[]
+    genres: string[]
     onChange?: (value: any, index: number) => void
-    getSelectedGenres: (genres: string[]) => void
 }
 export const Sources: React.FunctionComponent<SourcesProps> = (props) => {
-    const { size, onChange, sources, selectedGenreValue, topGenres, getSelectedGenres } = props
+    const { size, onChange, sources, genres } = props
     const [showGenre, setShowGenre] = React.useState(false)
     const [isOpen, setIsOpen] = React.useState(false)
-
-    React.useEffect(() => {
-        getSelectedGenres([selectedGenreValue])
-    }, [selectedGenreValue])
 
     return (
         <Box align="center">
@@ -84,7 +78,7 @@ export const Sources: React.FunctionComponent<SourcesProps> = (props) => {
                                     <Select
                                         size="small"
                                         id="genre-select"
-                                        options={topGenres}
+                                        options={genres}
                                         onChange={({ option }) => {
                                             onChange(option, 4)
                                             onChange(true, 3)
@@ -95,16 +89,18 @@ export const Sources: React.FunctionComponent<SourcesProps> = (props) => {
                                         placeholder="a genre"
                                         onSearch={(search) => {
                                             onChange(
-                                                topGenres.find((o) => o.includes(search)),
+                                                genres.find((o) => o.includes(search)),
                                                 4
                                             )
                                         }}
-                                        value={selectedGenreValue}
+                                        value={sources.genres}
                                     />
                                 </Box>
                             ) : (
                                 <Box>
-                                    <Text size="xsmall">{selectedGenreValue || "a genre"}</Text>
+                                    <Text size="xsmall">
+                                        {sources.genres[0] ? sources.genres : "a genre"}
+                                    </Text>
                                 </Box>
                             )
                         }
@@ -128,7 +124,7 @@ export const Sources: React.FunctionComponent<SourcesProps> = (props) => {
             {showGenre && size === "small" && (
                 <Layer
                     onClickOutside={() => {
-                        if (!selectedGenreValue) {
+                        if (!sources.genres[0]) {
                             onChange(false, 3)
                         }
                         setIsOpen(false)
@@ -164,7 +160,7 @@ export const Sources: React.FunctionComponent<SourcesProps> = (props) => {
                             background={{ color: "#34495E", opacity: 0.9 }}
                         >
                             <Select
-                                options={topGenres}
+                                options={genres}
                                 onChange={({ option }) => {
                                     onChange(option, 4)
                                     if (!sources.recommended) onChange(true, 3)
@@ -174,16 +170,16 @@ export const Sources: React.FunctionComponent<SourcesProps> = (props) => {
                                 placeholder="select a genre"
                                 onSearch={(search) => {
                                     onChange(
-                                        topGenres.find((o) => o.includes(search)),
+                                        genres.find((o) => o.includes(search)),
                                         4
                                     )
                                 }}
-                                value={selectedGenreValue}
+                                value={sources.genres}
                             />
                             <Box align="center" direction="row" gap="medium">
                                 <Button
                                     small
-                                    disabled={!selectedGenreValue}
+                                    disabled={!sources.genres[0]}
                                     icon={<Checkmark />}
                                     color="neutral-3"
                                     onClick={() => {

--- a/ui/sources/Sources.tsx
+++ b/ui/sources/Sources.tsx
@@ -33,7 +33,7 @@ export const Sources: React.FunctionComponent<SourcesProps> = (props) => {
                         label={
                             <Box>
                                 <Text size={size !== "small" ? "medium" : "xsmall"}>
-                                    your saved/liked
+                                    your liked songs
                                 </Text>
                             </Box>
                         }

--- a/ui/track/Track.tsx
+++ b/ui/track/Track.tsx
@@ -263,7 +263,7 @@ export const Track: React.FunctionComponent<TrackProps> = (trackProps) => {
                     <Button
                         id="remove-track-btn"
                         color="dark-1"
-                        title="remove from moodqueue"
+                        title="remove"
                         icon={<SubtractCircle color="status-error" size="large" />}
                         onClick={() => {
                             onClickRemove()

--- a/ui/user-details/UserDetails.tsx
+++ b/ui/user-details/UserDetails.tsx
@@ -1,8 +1,12 @@
-import React from "react"
+import React, { useState } from "react"
 import { motion } from "framer-motion"
-import { Box, Heading, Avatar } from "grommet"
-import { User } from "grommet-icons"
+import { Box, Heading, Avatar, Layer, Anchor } from "grommet"
+import { Spotify, User } from "grommet-icons"
 import { UserInfo } from "../../types/UserInfo"
+import { Logout } from "@styled-icons/heroicons-outline/Logout"
+import { useAuth } from "../../common/hooks/useAuth"
+import { Button } from "../button/Button"
+import { colorMovementSettings } from "../../components/animations/motion"
 
 interface UserDetailsProps {
     user: UserInfo
@@ -10,43 +14,118 @@ interface UserDetailsProps {
 }
 export const UserDetails: React.FunctionComponent<UserDetailsProps> = (props) => {
     const { user, small } = props
+    const { logOut } = useAuth()
+    const [showLayer, setShowLayer] = useState(false)
 
     return (
-        <motion.div whileHover={{ scale: 1.1 }} whileTap={{ scale: 0.9 }}>
-            <Box
-                direction="row"
-                align="center"
-                gap="small"
-                onClick={() => window.open(user.profileUrl, "_blank")}
-                title="click to open your spotify profile"
-            >
-                {!small && (
-                    <Heading
-                        textAlign="center"
-                        margin="none"
-                        id="username-txt"
-                        size="small"
-                        style={{ userSelect: "none" }}
-                    >
-                        {user.name}
-                    </Heading>
-                )}
-                {user.profileImages[0] ? (
-                    <Avatar
-                        id="avatar-profile-image"
-                        src={user.profileImages[0].url}
-                        border={{ size: "small", side: "all", color: "accent-1" }}
-                    />
-                ) : (
-                    <Avatar
-                        id="avatar-default"
-                        background="accent-2"
-                        border={{ size: "small", side: "all", color: "accent-1" }}
-                    >
-                        <User color="accent-1" />
-                    </Avatar>
-                )}
-            </Box>
-        </motion.div>
+        <Box>
+            <motion.div whileHover={{ scale: 1.1 }} whileTap={{ scale: 0.9 }}>
+                <Box
+                    direction="row"
+                    align="center"
+                    gap="small"
+                    title="settings"
+                    onClick={() => setShowLayer(true)}
+                    focusIndicator={false}
+                    style={{ outline: "none" }}
+                >
+                    {!small && (
+                        <Heading
+                            textAlign="center"
+                            margin="none"
+                            id="username-txt"
+                            size="small"
+                            style={{ userSelect: "none" }}
+                        >
+                            {user.name}
+                        </Heading>
+                    )}
+                    {user.profileImages[0] ? (
+                        <Avatar
+                            id="avatar-profile-image"
+                            src={user.profileImages[0].url}
+                            border={{ size: "small", side: "all", color: "accent-1" }}
+                        />
+                    ) : (
+                        <Avatar
+                            id="avatar-default"
+                            background="accent-2"
+                            border={{ size: "small", side: "all", color: "accent-1" }}
+                        >
+                            <User color="accent-1" />
+                        </Avatar>
+                    )}
+                </Box>
+            </motion.div>
+            {showLayer && (
+                <Layer
+                    id="settings-layer"
+                    position={small ? "bottom" : "top-right"}
+                    responsive={false}
+                    margin="xsmall"
+                    onClickOutside={() => setShowLayer(false)}
+                    style={{
+                        background: "transparent",
+                        width: small ? "100%" : undefined,
+                    }}
+                >
+                    <motion.div animate={colorMovementSettings} style={{ borderRadius: 30 }}>
+                        <Box
+                            align="center"
+                            pad={{ horizontal: "large", vertical: "medium" }}
+                            background={{ dark: true }}
+                            round
+                            justify="between"
+                            gap="medium"
+                        >
+                            <Box align="center" gap="xsmall">
+                                {user.profileImages[0] ? (
+                                    <Avatar
+                                        id="avatar-profile-image"
+                                        src={user.profileImages[0].url}
+                                        title={user.name}
+                                        size="xlarge"
+                                        border={{ size: "small", side: "all", color: "accent-1" }}
+                                    />
+                                ) : (
+                                    <Avatar
+                                        id="avatar-default"
+                                        background="accent-2"
+                                        size="xlarge"
+                                        title={user.name}
+                                        border={{ size: "small", side: "all", color: "accent-1" }}
+                                    >
+                                        <User color="accent-1" />
+                                    </Avatar>
+                                )}
+                                <motion.div whileHover={{ scale: 1.1 }} whileTap={{ scale: 0.9 }}>
+                                    <Anchor
+                                        id="spotify-anchor"
+                                        alignSelf="center"
+                                        href={user.profileUrl}
+                                        title="click to open your spotify profile!"
+                                        target="blank"
+                                        label="open your profile"
+                                        icon={<Spotify />}
+                                    />
+                                </motion.div>
+                            </Box>
+                            <Button
+                                text="log out"
+                                color="neutral-4"
+                                icon={
+                                    <Logout
+                                        width={small ? "24px" : "26px"}
+                                        height={small ? "24px" : "26px"}
+                                    />
+                                }
+                                onClick={logOut}
+                                small
+                            />
+                        </Box>
+                    </motion.div>
+                </Layer>
+            )}
+        </Box>
     )
 }

--- a/ui/user-details/UserDetails.tsx
+++ b/ui/user-details/UserDetails.tsx
@@ -76,9 +76,9 @@ export const UserDetails: React.FunctionComponent<UserDetailsProps> = (props) =>
                             background={{ dark: true }}
                             round
                             justify="between"
-                            gap="medium"
+                            gap={small ? "medium" : "small"}
                         >
-                            <Box align="center" gap="xsmall">
+                            <Box align="center">
                                 {user.profileImages[0] ? (
                                     <Avatar
                                         id="avatar-profile-image"
@@ -98,6 +98,20 @@ export const UserDetails: React.FunctionComponent<UserDetailsProps> = (props) =>
                                         <User color="accent-1" />
                                     </Avatar>
                                 )}
+                                {small && (
+                                    <Heading
+                                        textAlign="center"
+                                        margin="none"
+                                        id="username-txt"
+                                        size="small"
+                                        color="light-2"
+                                        style={{ userSelect: "none" }}
+                                    >
+                                        {user.name}
+                                    </Heading>
+                                )}
+                            </Box>
+                            <Box align="center" gap={small ? "medium" : "small"}>
                                 <motion.div whileHover={{ scale: 1.1 }} whileTap={{ scale: 0.9 }}>
                                     <Anchor
                                         id="spotify-anchor"
@@ -105,23 +119,23 @@ export const UserDetails: React.FunctionComponent<UserDetailsProps> = (props) =>
                                         href={user.profileUrl}
                                         title="click to open your spotify profile!"
                                         target="blank"
-                                        label="open your profile"
+                                        label="open profile"
                                         icon={<Spotify />}
                                     />
                                 </motion.div>
+                                <Button
+                                    text="log out"
+                                    color="neutral-4"
+                                    icon={
+                                        <Logout
+                                            width={small ? "24px" : "26px"}
+                                            height={small ? "24px" : "26px"}
+                                        />
+                                    }
+                                    onClick={logOut}
+                                    small
+                                />
                             </Box>
-                            <Button
-                                text="log out"
-                                color="neutral-4"
-                                icon={
-                                    <Logout
-                                        width={small ? "24px" : "26px"}
-                                        height={small ? "24px" : "26px"}
-                                    />
-                                }
-                                onClick={logOut}
-                                small
-                            />
                         </Box>
                     </motion.div>
                 </Layer>


### PR DESCRIPTION
when i was showing my aunt moodqueue on her phone, i discovered that because her spotify account was linked to her facebook and not just with a simple email and password, she was forced to sign in every single time because her phone wasn't asking her to remember her credentials for moodqueue. this resulted in both poor ux and that weird shrunken viewport like i told you about a while back that sometimes happens on mobile. so, to solve this, i figured that using the refresh token would work as we could persist it in between sessions with localStorage and then use that stored token to get a new access token thus ensuring all users that they would never have to sign in to moodqueue again. since i added in a way to retrieve a new access token from refresh, i also started adding in the necessary calls wherever needed if a spotify endpoint returned a 401 (the error code that would be returned if access token expired.) 