### PR TITLE
Resolve patch/Results Overview

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ yarn-error.log*
 
 # storybook
 /storybook-static
+
+# vs-code
+.vscode

--- a/components/animations/motion.ts
+++ b/components/animations/motion.ts
@@ -127,20 +127,3 @@ export const trackDetailsVariants = (size: string) => {
         }
     }
 }
-
-export const resultsOverviewVariants = () => {
-    return {
-        open: {
-            scale: 1,
-            y: 0,
-            x: 0,
-            opacity: 1,
-        },
-        closed: {
-            scale: 1,
-            opacity: 0,
-            zIndex: 0,
-            y: 500,
-        },
-    }
-}

--- a/components/animations/motion.ts
+++ b/components/animations/motion.ts
@@ -112,3 +112,20 @@ export const trackDetailsVariants = (size: string) => {
         }
     }
 }
+
+export const resultsOverviewVariants = () => {
+    return {
+        open: {
+            scale: 1,
+            y: 0,
+            x: 0,
+            opacity: 1,
+        },
+        closed: {
+            scale: 1,
+            opacity: 0,
+            zIndex: 0,
+            y: 500,
+        },
+    }
+}

--- a/components/form/souce/source.spec.tsx
+++ b/components/form/souce/source.spec.tsx
@@ -54,6 +54,23 @@ describe("<SourceSelection />", () => {
         expect(wrapper.find("#artists-checkbox")).to.have.length(1)
     })
 
+    it("renders emojis for all sources", () => {
+        const wrapper = render(
+            <SourceSelection
+                size={"large"}
+                source={exampleFormSelection}
+                progress={0}
+                dispatch={jest.fn()}
+                genres={[]}
+            />
+        )
+
+        expect(wrapper.find("#saved-checkbox-label")).to.have.length(1)
+        expect(wrapper.find("#tracks-checkbox-label")).to.have.length(1)
+        expect(wrapper.find("#artists-checkbox-label")).to.have.length(1)
+        expect(wrapper.find("#recommended-checkbox-label")).to.have.length(1)
+    })
+
     it("renders tracks checkbox", () => {
         const wrapper = render(
             <SourceSelection

--- a/components/results/result-list/result-list.tsx
+++ b/components/results/result-list/result-list.tsx
@@ -18,8 +18,8 @@ export const ResultList: FunctionComponent<ResultListProps> = (props) => {
                 overflow={{ vertical: "auto", horizontal: "hidden" }}
                 fill
                 pad={{
-                    horizontal: size !== "small" ? "xlarge" : "none",
-                    vertical: "small",
+                    horizontal: size === "large" ? "xlarge" : size === "medium" ? "large" : "none",
+                    vertical: "xsmall",
                 }}
                 gap="medium"
                 style={{ touchAction: "pan-y" }}

--- a/components/results/results.spec.tsx
+++ b/components/results/results.spec.tsx
@@ -141,7 +141,7 @@ describe("<Results />", () => {
     })
 
     it("renders results overview", () => {
-        const wrapper = mount(
+        const wrapper = shallow(
             <Results
                 size={"large"}
                 mood={Mood.SLEEPY}
@@ -152,7 +152,7 @@ describe("<Results />", () => {
             />
         )
         expect(wrapper.find("#overview-bx").at(0).text()).to.contain(
-            "here's your sleepy moodqueue..."
+            "here's your 2-track sleepy moodqueue..."
         )
     })
 

--- a/components/results/results.spec.tsx
+++ b/components/results/results.spec.tsx
@@ -96,7 +96,7 @@ describe("<Results />", () => {
             />
         )
 
-        expect(wrapper.find("#desc-num-songs").text()).to.contain("loading...")
+        expect(wrapper.find("#results-header-txt").text()).to.contain("loading...")
     })
 
     it("renders number of tracks when tracks are defined", async () => {
@@ -144,8 +144,8 @@ describe("<Results />", () => {
         })
     })
 
-    it("renders queue sources in description", () => {
-        const wrapper = render(
+    it("renders results overview", () => {
+        const wrapper = mount(
             <Results
                 selectedGenreValue={""}
                 size={"large"}
@@ -156,7 +156,24 @@ describe("<Results />", () => {
                 userProduct="premium"
             />
         )
-        expect(wrapper.find("#desc-sources").text()).to.contain("saved")
+        expect(wrapper.find("#overview-bx").at(0).text()).to.contain(
+            "here's your sleepy moodqueue..."
+        )
+    })
+
+    it("renders mood in header", () => {
+        const wrapper = mount(
+            <Results
+                selectedGenreValue={""}
+                size={"large"}
+                mood={Mood.PARTY}
+                tracks={mockTracks}
+                source={source}
+                resetForm={jest.fn()}
+                userProduct="premium"
+            />
+        )
+        expect(wrapper.find("#results-header-txt").at(0).text()).to.contain("party")
     })
 
     it("renders <ResultList /> when queue has songs", async () => {

--- a/components/results/results.spec.tsx
+++ b/components/results/results.spec.tsx
@@ -141,7 +141,7 @@ describe("<Results />", () => {
     })
 
     it("renders results overview", () => {
-        const wrapper = shallow(
+        const wrapper = render(
             <Results
                 size={"large"}
                 mood={Mood.SLEEPY}
@@ -151,9 +151,7 @@ describe("<Results />", () => {
                 userProduct="premium"
             />
         )
-        expect(wrapper.find("#overview-bx").at(0).text()).to.contain(
-            "here's your 2-track sleepy moodqueue..."
-        )
+        expect(wrapper.find("#overview-bx").length).to.eql(1)
     })
 
     it("renders mood in header", () => {
@@ -168,6 +166,20 @@ describe("<Results />", () => {
             />
         )
         expect(wrapper.find("#results-header-txt").at(0).text()).to.contain("party")
+    })
+
+    it("renders source emoji in header", () => {
+        const wrapper = render(
+            <Results
+                size={"large"}
+                mood={Mood.PARTY}
+                tracks={mockTracks}
+                source={source}
+                resetForm={jest.fn()}
+                userProduct="premium"
+            />
+        )
+        expect(wrapper.find("#saved-tooltip").length).to.be.eql(1)
     })
 
     it("renders <ResultList /> when queue has songs", async () => {

--- a/components/results/results.tsx
+++ b/components/results/results.tsx
@@ -53,13 +53,7 @@ export const Results: FunctionComponent<ResultsProps> = (props) => {
     return (
         <Box align="center" fill>
             <Box align="center" justify="between" gap={size === "small" ? "none" : "small"} fill>
-                <ResultsOverview
-                    tracks={state.tracks}
-                    size={size}
-                    mood={mood}
-                    selectedGenreValue={source.genres[0]}
-                    source={source}
-                />
+                <ResultsOverview tracks={state.tracks} size={size} mood={mood} source={source} />
                 <Box
                     overflow="hidden"
                     gap="medium"

--- a/components/results/results.tsx
+++ b/components/results/results.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent, Reducer, useEffect, useReducer, useState } from "react"
-import { Box, Layer } from "grommet"
+import { Box } from "grommet"
 import { Mood } from "../../types/Mood"
 import { FormSelection } from "../../types/FormSelection"
 import { useSpotify } from "../../common/hooks/useSpotify"
@@ -15,7 +15,6 @@ import {
     update,
     updateTrackToShow,
 } from "./reducer"
-import { getSourcesString } from "../../common/Helpers"
 import { Options } from "./options"
 import { ResultList } from "./result-list"
 import { Track } from "../../types/Track"
@@ -23,8 +22,8 @@ import { motion } from "framer-motion"
 import { baseItemTop } from "../animations/motion"
 import { Button } from "../../ui/button/Button"
 import { Description } from "../../ui/description/Description"
-import ReactTooltip from "react-tooltip"
 import { Confirmation } from "../../ui/confirmation/Confirmation"
+import { ResultsOverview } from "../../ui/results-overview/ResultsOverview"
 
 interface ResultsProps {
     size: string
@@ -55,31 +54,13 @@ export const Results: FunctionComponent<ResultsProps> = (props) => {
     return (
         <Box align="center" fill>
             <Box align="center" justify="between" gap={size === "small" ? "none" : "small"} fill>
-                <Box direction="row" border="between" gap="small" align="center">
-                    <Description
-                        id="desc-num-songs"
-                        textAlign="center"
-                        size={size !== "small" ? "xlarge" : "medium"}
-                        weight="bold"
-                        text={
-                            state.tracks
-                                ? state.tracks.length +
-                                  " " +
-                                  `${mood >= 0 ? Mood[mood].toLowerCase() + " songs" : " songs"}`
-                                : "loading..."
-                        }
-                    />
-                    <Description
-                        id="desc-sources"
-                        textAlign="center"
-                        size={size !== "small" ? "xlarge" : "medium"}
-                        text={`based on ${
-                            !selectedGenreValue
-                                ? "your " + getSourcesString(source)
-                                : selectedGenreValue.replace("-", " ")
-                        }`}
-                    />
-                </Box>
+                <ResultsOverview
+                    tracks={state.tracks}
+                    size={size}
+                    mood={mood}
+                    selectedGenreValue={selectedGenreValue}
+                    source={source}
+                />
                 <Box
                     overflow="hidden"
                     gap="medium"
@@ -166,6 +147,7 @@ export const Results: FunctionComponent<ResultsProps> = (props) => {
                                     text:
                                         "unfortunately, the add-to-queue feature is limited to spotify premium users only :(",
                                     id: "queue-tooltip",
+                                    active: true,
                                 }}
                             />
                         )}
@@ -192,6 +174,7 @@ export const Results: FunctionComponent<ResultsProps> = (props) => {
                                 text:
                                     "click to either create a new moodqueue playlist or add to an existing one!",
                                 id: "playlist-tooltip",
+                                active: true,
                             }}
                         />
                         <Button
@@ -210,6 +193,7 @@ export const Results: FunctionComponent<ResultsProps> = (props) => {
                                         ? "click here to add the above songs to your queue!"
                                         : "unfortunately, this feature is limited to spotify premium users only :(",
                                 id: "queue-tooltip",
+                                active: true,
                             }}
                         />
                         <Button

--- a/ui/button/Button.tsx
+++ b/ui/button/Button.tsx
@@ -5,7 +5,7 @@ import { Tooltip } from "./Tooltip"
 
 interface ButtonProps {
     id?: string
-    text?: string
+    text?: any
     icon?: any
     disabled?: any
     fill?: boolean

--- a/ui/button/Button.tsx
+++ b/ui/button/Button.tsx
@@ -52,6 +52,7 @@ export const Button: React.FunctionComponent<ButtonProps> = (props) => {
                         margin={margin}
                         color={color === undefined ? "accent-3" : color}
                         focusIndicator={false}
+                        size="small"
                     />
                 </motion.div>
             )
@@ -71,6 +72,7 @@ export const Button: React.FunctionComponent<ButtonProps> = (props) => {
                         margin={margin}
                         color={color === undefined ? "accent-3" : color}
                         focusIndicator={false}
+                        size="small"
                     />
                 </motion.div>
             </Tooltip>
@@ -92,6 +94,7 @@ export const Button: React.FunctionComponent<ButtonProps> = (props) => {
                         label={text}
                         margin={margin}
                         focusIndicator={false}
+                        size="small"
                     />
                 </motion.div>
             )
@@ -111,6 +114,7 @@ export const Button: React.FunctionComponent<ButtonProps> = (props) => {
                         label={text}
                         margin={margin}
                         focusIndicator={false}
+                        size="small"
                     />
                 </motion.div>
             </Tooltip>

--- a/ui/button/Tooltip.tsx
+++ b/ui/button/Tooltip.tsx
@@ -18,7 +18,7 @@ export const Tooltip: React.FunctionComponent<TooltipProps> = (props) => {
                     {children}
                 </a>
                 <ReactTooltip id={tooltip.id}>
-                    <Box width="small" align="center">
+                    <Box width={{ max: "small" }} align="center">
                         <Description text={tooltip.text} textAlign="center" />
                     </Box>
                 </ReactTooltip>

--- a/ui/button/Tooltip.tsx
+++ b/ui/button/Tooltip.tsx
@@ -10,16 +10,20 @@ interface TooltipProps {
 
 export const Tooltip: React.FunctionComponent<TooltipProps> = (props) => {
     const { tooltip, children } = props
-    return (
-        <Box align="center" id="tooltip-btn">
-            <a data-for={tooltip.id} data-tip>
-                {children}
-            </a>
-            <ReactTooltip id={tooltip.id}>
-                <Box width="small" align="center">
-                    <Description text={tooltip.text} textAlign="center" />
-                </Box>
-            </ReactTooltip>
-        </Box>
-    )
+
+    if (tooltip.active) {
+        return (
+            <Box align="center" id="tooltip-btn">
+                <a data-for={tooltip.id} data-tip>
+                    {children}
+                </a>
+                <ReactTooltip id={tooltip.id}>
+                    <Box width="small" align="center">
+                        <Description text={tooltip.text} textAlign="center" />
+                    </Box>
+                </ReactTooltip>
+            </Box>
+        )
+    }
+    return children
 }

--- a/ui/description/Description.tsx
+++ b/ui/description/Description.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { Heading as Header, Text } from "grommet"
+import { Box, Heading as Header, Text } from "grommet"
 
 interface DescProps {
     id?: string
@@ -8,26 +8,53 @@ interface DescProps {
     weight?: any
     size?: any
     textAlign?: any
+    truncate?: boolean
 }
 export const Description: React.FunctionComponent<DescProps> = (props) => {
-    const { id, text, header, weight, size, textAlign } = props
+    const { id, text, header, weight, size, textAlign, truncate } = props
 
-    if (!header) {
+    if (truncate) {
+        if (!header) {
+            return (
+                <Box overflow="hidden">
+                    <Text id={id} weight={weight} size={size} textAlign={textAlign} truncate>
+                        {text}
+                    </Text>
+                </Box>
+            )
+        }
         return (
-            <Text id={id} weight={weight} size={size} textAlign={textAlign}>
+            <Box overflow="hidden">
+                <Header
+                    id={id}
+                    truncate
+                    size={size}
+                    textAlign={textAlign}
+                    margin="none"
+                    style={{ userSelect: "none" }}
+                >
+                    {text}
+                </Header>
+            </Box>
+        )
+    } else {
+        if (!header) {
+            return (
+                <Text id={id} weight={weight} size={size} textAlign={textAlign}>
+                    {text}
+                </Text>
+            )
+        }
+        return (
+            <Header
+                id={id}
+                size={size}
+                textAlign={textAlign}
+                margin="none"
+                style={{ userSelect: "none" }}
+            >
                 {text}
-            </Text>
+            </Header>
         )
     }
-    return (
-        <Header
-            id={id}
-            size={size}
-            textAlign={textAlign}
-            margin="none"
-            style={{ userSelect: "none" }}
-        >
-            {text}
-        </Header>
-    )
 }

--- a/ui/results-overview/ResultsOverview.spec.tsx
+++ b/ui/results-overview/ResultsOverview.spec.tsx
@@ -37,12 +37,12 @@ describe("<ResultsOverview />", () => {
             testComponent({
                 size: "large",
                 tracks: mockTracks,
-                selectedGenreValue: undefined,
                 source: {
                     saved: false,
                     artists: false,
                     tracks: false,
                     recommended: false,
+                    genres: ["ambient"],
                 },
                 mood: Mood.HAPPY,
             })

--- a/ui/results-overview/ResultsOverview.spec.tsx
+++ b/ui/results-overview/ResultsOverview.spec.tsx
@@ -1,0 +1,51 @@
+import { Grommet, grommet } from "grommet"
+import { render } from "enzyme"
+import { ResultsOverview } from "./ResultsOverview"
+import { Mood } from "../../types/Mood"
+import { Track } from "../../types/Track"
+
+const mockTracks: Track[] = [
+    {
+        previewUrl: "",
+        name: "myMockTrack1",
+        artist: "myMockArtist1",
+        imageLink: "",
+        id: "1",
+        uri: "",
+    },
+    {
+        previewUrl: "",
+        name: "myMockTrack2",
+        artist: "myMockArtist2",
+        imageLink: "",
+        id: "2",
+        uri: "",
+    },
+]
+
+describe("<ResultsOverview />", () => {
+    let testComponent
+    beforeEach(() => {
+        testComponent = (props) => (
+            <Grommet theme={grommet}>
+                <ResultsOverview {...props} />
+            </Grommet>
+        )
+    })
+    it("renders overview of results", () => {
+        render(
+            testComponent({
+                size: "large",
+                tracks: mockTracks,
+                selectedGenreValue: undefined,
+                source: {
+                    saved: false,
+                    artists: false,
+                    tracks: false,
+                    recommended: false,
+                },
+                mood: Mood.HAPPY,
+            })
+        )
+    })
+})

--- a/ui/results-overview/ResultsOverview.stories.tsx
+++ b/ui/results-overview/ResultsOverview.stories.tsx
@@ -32,12 +32,12 @@ export const resultsOverview = () =>
         <ResultsOverview
             size="large"
             tracks={mockTracks}
-            selectedGenreValue={undefined}
             source={{
                 saved: false,
                 artists: false,
                 tracks: false,
                 recommended: false,
+                genres: [""],
             }}
             mood={Mood.HAPPY}
         />

--- a/ui/results-overview/ResultsOverview.stories.tsx
+++ b/ui/results-overview/ResultsOverview.stories.tsx
@@ -1,0 +1,44 @@
+// src/stories/ResultsOverview.stories.tsx
+
+import * as React from "react"
+import { Mood } from "../../types/Mood"
+import { Track } from "../../types/Track"
+import { withGrommet } from "../wrapper"
+import { ResultsOverview } from "./ResultsOverview"
+
+export default { title: "ResultsOverview" }
+
+const mockTracks: Track[] = [
+    {
+        previewUrl: "",
+        name: "myMockTrack1",
+        artist: "myMockArtist1",
+        imageLink: "",
+        id: "1",
+        uri: "",
+    },
+    {
+        previewUrl: "",
+        name: "myMockTrack2",
+        artist: "myMockArtist2",
+        imageLink: "",
+        id: "2",
+        uri: "",
+    },
+]
+
+export const resultsOverview = () =>
+    withGrommet(
+        <ResultsOverview
+            size="large"
+            tracks={mockTracks}
+            selectedGenreValue={undefined}
+            source={{
+                saved: false,
+                artists: false,
+                tracks: false,
+                recommended: false,
+            }}
+            mood={Mood.HAPPY}
+        />
+    )

--- a/ui/results-overview/ResultsOverview.tsx
+++ b/ui/results-overview/ResultsOverview.tsx
@@ -1,130 +1,101 @@
-import { motion } from "framer-motion"
-import { Box, Layer } from "grommet"
-import React, { useState } from "react"
-import { getSourcesString } from "../../common/Helpers"
-import { resultsOverviewVariants } from "../../components/animations/motion"
+import { Box } from "grommet"
+import React from "react"
 import { FormSelection } from "../../types/FormSelection"
 import { Mood } from "../../types/Mood"
 import { Track } from "../../types/Track"
 import { Tooltip } from "../button/Tooltip"
 import { Description } from "../description/Description"
+import { Heart as Liked } from "@styled-icons/remix-fill/Heart"
+import { Music as TopTracks } from "@styled-icons/evaicons-solid/Music"
+import { MusicArtist as TopArtists } from "@styled-icons/zondicons/MusicArtist"
+import { FolderMusic as Genre } from "@styled-icons/entypo/FolderMusic"
 
 interface ResultsOverviewProps {
     size: any
     source: FormSelection
-    selectedGenreValue: string
     tracks: Track[]
     mood: Mood
 }
 
 export const ResultsOverview: React.FunctionComponent<ResultsOverviewProps> = (props) => {
-    const { size, source, selectedGenreValue, tracks, mood } = props
-    const [showHeaderModal, setShowHeaderModal] = useState(false)
-    const [isOpen, setIsOpen] = useState(false)
+    const { size, source, tracks, mood } = props
 
     return (
         <Box align="center" id="overview-bx">
-            <Tooltip
-                tooltip={{
-                    text: "click for an overview of your moodqueue!",
-                    id: "overview-tooltip",
-                    active: size !== "small",
-                }}
+            <Box
+                direction="row"
+                id="results-header-bx"
+                gap="medium"
+                align="center"
+                pad={{ horizontal: "medium", vertical: "xsmall" }}
+                margin={{ horizontal: "small" }}
+                background={{ color: "light-2", opacity: 0.1 }}
+                round
+                focusIndicator={false}
+                style={{ outline: "none" }}
+                border="between"
             >
-                <motion.div
-                    whileTap={{ scale: 0.9 }}
-                    style={{
-                        width: "100%",
-                        alignItems: "center",
-                        display: "flex",
-                        justifyContent: "center",
-                        borderRadius: 30,
-                    }}
-                >
-                    <Box
-                        direction="row"
-                        gap="medium"
-                        align="center"
-                        pad={{ horizontal: "medium", vertical: "xsmall" }}
-                        margin={{ horizontal: "small" }}
-                        onClick={() => {
-                            setIsOpen(true)
-                            setShowHeaderModal(true)
-                        }}
-                        background={{ color: "light-2", opacity: 0.1 }}
-                        round
-                        focusIndicator={false}
-                        style={{ outline: "none" }}
-                    >
-                        <Description
-                            truncate
-                            id="results-header-txt"
-                            textAlign="center"
-                            size={size !== "small" ? "xlarge" : "medium"}
-                            weight="bold"
-                            text={
-                                tracks
-                                    ? "here's your " +
-                                      `${
-                                          mood >= 0
-                                              ? Mood[mood].toLowerCase() + " moodqueue..."
-                                              : "moodqueue..."
-                                      }`
-                                    : "loading..."
-                            }
-                        />
-                    </Box>
-                </motion.div>
-            </Tooltip>
-            {showHeaderModal && (
-                <Layer
-                    onClickOutside={() => {
-                        setIsOpen(false)
-                        setTimeout(() => setShowHeaderModal(false), 500)
-                    }}
-                    responsive={false}
-                    position="center"
-                    style={{ background: "transparent" }}
-                    animation={false}
-                >
-                    <motion.div
-                        variants={resultsOverviewVariants()}
-                        animate={isOpen ? "open" : "closed"}
-                        initial={{ opacity: 0, y: -500 }}
-                        transition={{ duration: 0.5 }}
-                    >
-                        <Box
-                            gap="medium"
-                            align="center"
-                            round="large"
-                            pad="large"
-                            background={{ color: "#5DADE2", opacity: 0.8, dark: true }}
+                <Description
+                    id="results-header-txt"
+                    truncate
+                    textAlign="center"
+                    size={size !== "small" ? "xlarge" : "medium"}
+                    weight="bold"
+                    text={
+                        tracks
+                            ? tracks.length +
+                              " " +
+                              `${mood >= 0 ? Mood[mood].toLowerCase() + " songs" : "songs"}`
+                            : "loading..."
+                    }
+                />
+                <Box gap="small" align="center" direction="row" id="tooltip-sources-bx">
+                    {source.saved && (
+                        <Tooltip
+                            tooltip={{
+                                active: true,
+                                id: "saved-tooltip",
+                                text: "your liked songs",
+                            }}
                         >
-                            <Description
-                                id="desc-num-songs"
-                                textAlign="center"
-                                size={size !== "small" ? "xlarge" : "medium"}
-                                weight="bold"
-                                text={
-                                    tracks.length +
-                                    " " +
-                                    `${mood >= 0 ? Mood[mood].toLowerCase() + " songs" : " songs"}`
-                                }
-                            />
-                            <Description
-                                id="desc-sources"
-                                textAlign="center"
-                                size={size !== "small" ? "xlarge" : "medium"}
-                                text={`based on ${
-                                    !selectedGenreValue
-                                        ? "your " + getSourcesString(source)
-                                        : selectedGenreValue.replace("-", " ")
-                                }`}
-                            />
-                        </Box>
-                    </motion.div>
-                </Layer>
-            )}
+                            <Liked width="24px" height="24px" />
+                        </Tooltip>
+                    )}
+                    {source.tracks && (
+                        <Tooltip
+                            tooltip={{
+                                active: true,
+                                id: "tracks-tooltip",
+                                text: "your top tracks",
+                            }}
+                        >
+                            <TopTracks width="24px" height="24px" />
+                        </Tooltip>
+                    )}
+                    {source.artists && (
+                        <Tooltip
+                            tooltip={{
+                                active: true,
+                                id: "artists-tooltip",
+                                text: "your top artists",
+                            }}
+                        >
+                            <TopArtists width="24px" height="24px" />
+                        </Tooltip>
+                    )}
+                    {source.genres[0] && (
+                        <Tooltip
+                            tooltip={{
+                                active: true,
+                                id: "genre-tooltip",
+                                text: source.genres[0].replace("-", " "),
+                            }}
+                        >
+                            <Genre width="24px" height="24px" />
+                        </Tooltip>
+                    )}
+                </Box>
+            </Box>
         </Box>
     )
 }

--- a/ui/results-overview/ResultsOverview.tsx
+++ b/ui/results-overview/ResultsOverview.tsx
@@ -1,0 +1,136 @@
+import { motion } from "framer-motion"
+import { Box, Layer } from "grommet"
+import React, { useState } from "react"
+import { getSourcesString } from "../../common/Helpers"
+import { resultsOverviewVariants } from "../../components/animations/motion"
+import { FormSelection } from "../../types/FormSelection"
+import { Mood } from "../../types/Mood"
+import { Track } from "../../types/Track"
+import { Tooltip } from "../button/Tooltip"
+import { Description } from "../description/Description"
+
+interface ResultsOverviewProps {
+    size: any
+    source: FormSelection
+    selectedGenreValue: string
+    tracks: Track[]
+    mood: Mood
+}
+
+export const ResultsOverview: React.FunctionComponent<ResultsOverviewProps> = (props) => {
+    const { size, source, selectedGenreValue, tracks, mood } = props
+    const [showHeaderModal, setShowHeaderModal] = useState(false)
+    const [isOpen, setIsOpen] = useState(false)
+
+    return (
+        <Box align="center">
+            <Tooltip
+                tooltip={{
+                    text: "click for an overview of your moodqueue!",
+                    id: "overview-tooltip",
+                    active: size !== "small",
+                }}
+            >
+                <motion.div
+                    whileTap={{ scale: 0.9 }}
+                    style={{
+                        width: "100%",
+                        alignItems: "center",
+                        display: "flex",
+                        justifyContent: "center",
+                        borderRadius: 30,
+                    }}
+                >
+                    <Box
+                        direction="row"
+                        gap="medium"
+                        align="center"
+                        pad={{ horizontal: "medium", vertical: "xsmall" }}
+                        margin={{ horizontal: "small" }}
+                        onClick={() => {
+                            setIsOpen(true)
+                            setShowHeaderModal(true)
+                        }}
+                        background={{ color: "light-2", opacity: 0.1 }}
+                        round
+                        focusIndicator={false}
+                        style={{ outline: "none" }}
+                    >
+                        <Description
+                            truncate
+                            id="desc-num-songs"
+                            textAlign="center"
+                            size={size !== "small" ? "xlarge" : "medium"}
+                            weight="bold"
+                            text={
+                                tracks
+                                    ? "here's your " +
+                                      `${
+                                          mood >= 0
+                                              ? Mood[mood].toLowerCase() + " moodqueue..."
+                                              : "moodqueue..."
+                                      }`
+                                    : "loading..."
+                            }
+                        />
+                    </Box>
+                </motion.div>
+            </Tooltip>
+            {showHeaderModal && (
+                <Layer
+                    onClickOutside={() => {
+                        setIsOpen(false)
+                        setTimeout(() => setShowHeaderModal(false), 500)
+                    }}
+                    responsive={false}
+                    position="center"
+                    style={{ background: "transparent" }}
+                    animation={false}
+                >
+                    <motion.div
+                        variants={resultsOverviewVariants()}
+                        animate={isOpen ? "open" : "closed"}
+                        initial={{ opacity: 0, y: -500 }}
+                        transition={{ duration: 0.5 }}
+                    >
+                        <Box
+                            gap="medium"
+                            align="center"
+                            round="large"
+                            pad="large"
+                            background={{ color: "#5DADE2", opacity: 0.8, dark: true }}
+                        >
+                            <Description
+                                id="desc-num-songs"
+                                textAlign="center"
+                                size={size !== "small" ? "xlarge" : "medium"}
+                                weight="bold"
+                                text={
+                                    tracks
+                                        ? tracks.length +
+                                          " " +
+                                          `${
+                                              mood >= 0
+                                                  ? Mood[mood].toLowerCase() + " songs"
+                                                  : " songs"
+                                          }`
+                                        : "loading..."
+                                }
+                            />
+                            <Description
+                                id="desc-sources"
+                                textAlign="center"
+                                size={size !== "small" ? "xlarge" : "medium"}
+                                text={`based on ${
+                                    !selectedGenreValue
+                                        ? "your " + getSourcesString(source)
+                                        : selectedGenreValue.replace("-", " ")
+                                }`}
+                            />
+                        </Box>
+                    </motion.div>
+                </Layer>
+            )}
+        </Box>
+    )
+}

--- a/ui/results-overview/ResultsOverview.tsx
+++ b/ui/results-overview/ResultsOverview.tsx
@@ -83,7 +83,7 @@ export const ResultsOverview: React.FunctionComponent<ResultsOverviewProps> = (p
                             <TopArtists width="24px" height="24px" />
                         </Tooltip>
                     )}
-                    {source.genres[0] && (
+                    {source.genres.length > 0 && (
                         <Tooltip
                             tooltip={{
                                 active: true,

--- a/ui/results-overview/ResultsOverview.tsx
+++ b/ui/results-overview/ResultsOverview.tsx
@@ -23,7 +23,7 @@ export const ResultsOverview: React.FunctionComponent<ResultsOverviewProps> = (p
     const [isOpen, setIsOpen] = useState(false)
 
     return (
-        <Box align="center">
+        <Box align="center" id="overview-bx">
             <Tooltip
                 tooltip={{
                     text: "click for an overview of your moodqueue!",
@@ -58,7 +58,7 @@ export const ResultsOverview: React.FunctionComponent<ResultsOverviewProps> = (p
                     >
                         <Description
                             truncate
-                            id="desc-num-songs"
+                            id="results-header-txt"
                             textAlign="center"
                             size={size !== "small" ? "xlarge" : "medium"}
                             weight="bold"
@@ -106,15 +106,9 @@ export const ResultsOverview: React.FunctionComponent<ResultsOverviewProps> = (p
                                 size={size !== "small" ? "xlarge" : "medium"}
                                 weight="bold"
                                 text={
-                                    tracks
-                                        ? tracks.length +
-                                          " " +
-                                          `${
-                                              mood >= 0
-                                                  ? Mood[mood].toLowerCase() + " songs"
-                                                  : " songs"
-                                          }`
-                                        : "loading..."
+                                    tracks.length +
+                                    " " +
+                                    `${mood >= 0 ? Mood[mood].toLowerCase() + " songs" : " songs"}`
                                 }
                             />
                             <Description

--- a/ui/sources/Sources.tsx
+++ b/ui/sources/Sources.tsx
@@ -33,7 +33,7 @@ export const Sources: React.FunctionComponent<SourcesProps> = (props) => {
                                 direction="row"
                                 align="center"
                                 gap="small"
-                                id="liked-checkbox-label"
+                                id="saved-checkbox-label"
                             >
                                 <Liked width="24px" height="24px" />
                                 <Text
@@ -109,7 +109,7 @@ export const Sources: React.FunctionComponent<SourcesProps> = (props) => {
                                     direction="row"
                                     align="center"
                                     gap="small"
-                                    id="genre-checkbox-label"
+                                    id="recommended-checkbox-label"
                                 >
                                     <Genre width="24px" height="24px" />
                                     <Box width="small">
@@ -140,10 +140,10 @@ export const Sources: React.FunctionComponent<SourcesProps> = (props) => {
                                     direction="row"
                                     align="center"
                                     gap="small"
-                                    id="genre-checkbox-label"
+                                    id="recommended-checkbox-label"
                                 >
                                     <Genre width="24px" height="24px" />
-                                    <Text size="xsmall">
+                                    <Text size="xsmall" textAlign="center">
                                         {sources.genres[0] ? sources.genres : "a genre"}
                                     </Text>
                                 </Box>

--- a/ui/sources/Sources.tsx
+++ b/ui/sources/Sources.tsx
@@ -6,6 +6,10 @@ import { FormSelection } from "../../types/FormSelection"
 import { Button } from "../button/Button"
 import { Close, Checkmark } from "grommet-icons"
 import { trackDetailsVariants } from "../../components/animations/motion"
+import { Heart as Liked } from "@styled-icons/remix-fill/Heart"
+import { Music as TopTracks } from "@styled-icons/evaicons-solid/Music"
+import { MusicArtist as TopArtists } from "@styled-icons/zondicons/MusicArtist"
+import { FolderMusic as Genre } from "@styled-icons/entypo/FolderMusic"
 
 interface SourcesProps {
     size?: any
@@ -25,8 +29,17 @@ export const Sources: React.FunctionComponent<SourcesProps> = (props) => {
                     <CheckBox
                         id="saved-checkbox"
                         label={
-                            <Box>
-                                <Text size={size !== "small" ? "medium" : "xsmall"}>
+                            <Box
+                                direction="row"
+                                align="center"
+                                gap="small"
+                                id="liked-checkbox-label"
+                            >
+                                <Liked width="24px" height="24px" />
+                                <Text
+                                    size={size !== "small" ? "medium" : "xsmall"}
+                                    textAlign="center"
+                                >
                                     your liked songs
                                 </Text>
                             </Box>
@@ -41,8 +54,17 @@ export const Sources: React.FunctionComponent<SourcesProps> = (props) => {
                     <CheckBox
                         id="tracks-checkbox"
                         label={
-                            <Box>
-                                <Text size={size !== "small" ? "medium" : "xsmall"}>
+                            <Box
+                                direction="row"
+                                align="center"
+                                gap="small"
+                                id="tracks-checkbox-label"
+                            >
+                                <TopTracks width="24px" height="24px" />
+                                <Text
+                                    size={size !== "small" ? "medium" : "xsmall"}
+                                    textAlign="center"
+                                >
                                     your top tracks
                                 </Text>
                             </Box>
@@ -57,8 +79,17 @@ export const Sources: React.FunctionComponent<SourcesProps> = (props) => {
                     <CheckBox
                         id="artists-checkbox"
                         label={
-                            <Box>
-                                <Text size={size !== "small" ? "medium" : "xsmall"}>
+                            <Box
+                                direction="row"
+                                align="center"
+                                gap="small"
+                                id="artists-checkbox-label"
+                            >
+                                <TopArtists width="24px" height="24px" />
+                                <Text
+                                    size={size !== "small" ? "medium" : "xsmall"}
+                                    textAlign="center"
+                                >
                                     your top artists
                                 </Text>
                             </Box>
@@ -74,30 +105,44 @@ export const Sources: React.FunctionComponent<SourcesProps> = (props) => {
                         id="recommended-checkbox"
                         label={
                             size !== "small" ? (
-                                <Box width="small">
-                                    <Select
-                                        size="small"
-                                        id="genre-select"
-                                        options={genres}
-                                        onChange={({ option }) => {
-                                            onChange(option, 4)
-                                            onChange(true, 3)
-                                        }}
-                                        dropHeight="small"
-                                        dropAlign={{ bottom: "top", left: "left" }}
-                                        closeOnChange={false}
-                                        placeholder="a genre"
-                                        onSearch={(search) => {
-                                            onChange(
-                                                genres.find((o) => o.includes(search)),
-                                                4
-                                            )
-                                        }}
-                                        value={sources.genres}
-                                    />
+                                <Box
+                                    direction="row"
+                                    align="center"
+                                    gap="small"
+                                    id="genre-checkbox-label"
+                                >
+                                    <Genre width="24px" height="24px" />
+                                    <Box width="small">
+                                        <Select
+                                            size="small"
+                                            id="genre-select"
+                                            options={genres}
+                                            onChange={({ option }) => {
+                                                onChange(option, 4)
+                                                onChange(true, 3)
+                                            }}
+                                            dropHeight="small"
+                                            dropAlign={{ bottom: "top", left: "left" }}
+                                            closeOnChange={false}
+                                            placeholder="a genre"
+                                            onSearch={(search) => {
+                                                onChange(
+                                                    genres.find((o) => o.includes(search)),
+                                                    4
+                                                )
+                                            }}
+                                            value={sources.genres}
+                                        />
+                                    </Box>
                                 </Box>
                             ) : (
-                                <Box>
+                                <Box
+                                    direction="row"
+                                    align="center"
+                                    gap="small"
+                                    id="genre-checkbox-label"
+                                >
+                                    <Genre width="24px" height="24px" />
                                     <Text size="xsmall">
                                         {sources.genres[0] ? sources.genres : "a genre"}
                                     </Text>


### PR DESCRIPTION
although this usually isn't a problem on web, i've been finding it annoying how much space the results header takes up when you select more than one source (that's usually how much it takes.) for example, selecting two sources and the driving mood usually winds up taking up more than one line on the results page causing all the tracks to be pushed down quite a bit. 

to remedy this, i thought that i would make the header into a button that the user would press to bring up their moodqueue overview which would be the content of the original header (10 party songs etc...) i figure that immediately after the form, users don't technically need to see the details of their moodqueue since they know what they selected. however, if they want to be reminded or see how many songs are left after removing some, they can open up the results overview modal to see that information. 