### PR TITLE
Resolve patch/queue-tests

### DIFF
--- a/common/hooks/useSpotify.tsx
+++ b/common/hooks/useSpotify.tsx
@@ -368,7 +368,6 @@ export const SpotifyProvider: React.FunctionComponent<SpotifyProviderProps> = (p
                         } else return status
                     })
                 ).then((resp) => {
-                    console.log(resp)
                     if (!resp.includes(204)) return false
                     else {
                         notifySuccess("success! check your queue :)")

--- a/common/hooks/useSpotify.tsx
+++ b/common/hooks/useSpotify.tsx
@@ -98,21 +98,20 @@ export const SpotifyProvider: React.FunctionComponent<SpotifyProviderProps> = (p
 
     const addSongToQueue = async (uri: string): Promise<Number> => {
         try {
-            await fetch(`https://api.spotify.com/v1/me/player/queue?uri=${uri}`, {
+            const res = await fetch(`https://api.spotify.com/v1/me/player/queue?uri=${uri}`, {
                 headers: {
                     Accept: "application/json",
                     "Content-Type": "application/json",
                     Authorization: "Bearer " + accessToken,
                 },
                 method: "POST",
-            }).then((res) => {
-                if (!res.ok && res.status !== 401) {
-                    notifyError(
-                        "Error adding songs to queue!\nSpotify must be playing music to add to queue."
-                    )
-                }
-                return res.status
             })
+            if (!res.ok && res.status !== 401) {
+                notifyError(
+                    "Error adding songs to queue!\nSpotify must be playing music to add to queue."
+                )
+            }
+            return res.status
         } catch (e) {
             return e.status
         }
@@ -366,11 +365,15 @@ export const SpotifyProvider: React.FunctionComponent<SpotifyProviderProps> = (p
                         if (status === 401) {
                             await refreshContext()
                             addToQueue(tracks)
-                        }
+                        } else return status
                     })
                 ).then((resp) => {
-                    if (resp.includes(undefined)) return false
-                    else return true
+                    console.log(resp)
+                    if (!resp.includes(204)) return false
+                    else {
+                        notifySuccess("success! check your queue :)")
+                        return true
+                    }
                 })
             } catch (e) {
                 notifyError(e)

--- a/components/results/results.tsx
+++ b/components/results/results.tsx
@@ -121,29 +121,21 @@ export const Results: FunctionComponent<ResultsProps> = (props) => {
                             }}
                             secondary
                         />
-                        {userProduct === "premium" ? (
-                            <Button
-                                small
-                                id="play-queue-btn"
-                                icon={<Queue width="24px" height="24px" />}
-                                onClick={async () => {
-                                    setShowQueueWarningModal(true)
-                                }}
-                            />
-                        ) : (
-                            <Button
-                                disabled
-                                small
-                                id="play-queue-btn"
-                                icon={<Queue width="24px" height="24px" />}
-                                tooltip={{
-                                    text:
-                                        "unfortunately, the add-to-queue feature is limited to spotify premium users only :(",
-                                    id: "queue-tooltip",
-                                    active: true,
-                                }}
-                            />
-                        )}
+                        <Button
+                            disabled={userProduct !== "premium"}
+                            small
+                            id="play-queue-btn"
+                            icon={<Queue width="24px" height="24px" />}
+                            tooltip={{
+                                text:
+                                    "unfortunately, the add-to-queue feature is limited to spotify premium users only :(",
+                                id: "queue-tooltip",
+                                active: userProduct !== "premium",
+                            }}
+                            onClick={async () => {
+                                setShowQueueWarningModal(true)
+                            }}
+                        />
                         <Button
                             small
                             id="reset-btn"
@@ -178,6 +170,7 @@ export const Results: FunctionComponent<ResultsProps> = (props) => {
                             icon={<Queue width="26px" height="26px" />}
                             onClick={async () => {
                                 const result = await addToQueue(state.tracks)
+                                console.log(result)
                                 if (result) resetForm()
                             }}
                             tooltip={{


### PR DESCRIPTION
i noticed that after i added tracks to the queue successfully, the app didn't return to the home page like it was supposed to.  this was to be expected as i couldn't test this functionality before, but i now added some status code checking to better control the flow of the app following user/queue interaction.

204 === everything went swimmingly so go back to form

or

anything else === something went wrong so give error message