### PR TITLE
resolve patch/bad-queue

### DIFF
--- a/common/hooks/useSpotify.tsx
+++ b/common/hooks/useSpotify.tsx
@@ -24,7 +24,7 @@ export interface SpotifyContextValue {
         mood: Mood,
         genres: string[]
     ) => Promise<Track[]>
-    addToQueue: (tracks: Track[]) => Promise<boolean>
+    addToQueue: (tracks: Track[]) => Promise<void>
     addToPlaylist: (tracks: Track[], mood: Mood, sources: FormSelection) => Promise<boolean>
     getAvailableSeedGenres: () => Promise<string[]>
 }
@@ -355,7 +355,7 @@ export const SpotifyProvider: React.FunctionComponent<SpotifyProviderProps> = (p
         })
     }
 
-    const addToQueue = async (tracks: Track[]): Promise<boolean> => {
+    const addToQueue = async (tracks: Track[]): Promise<void> => {
         Sentry.captureMessage(`add to queue`)
         if (tracks.length > 0) {
             try {
@@ -368,15 +368,10 @@ export const SpotifyProvider: React.FunctionComponent<SpotifyProviderProps> = (p
                         } else return status
                     })
                 ).then((resp) => {
-                    if (!resp.includes(204)) return false
-                    else {
-                        notifySuccess("success! check your queue :)")
-                        return true
-                    }
+                    if (resp.includes(204)) notifySuccess("success! check your queue :)")
                 })
             } catch (e) {
                 notifyError(e)
-                return false
             }
         } else notifyInfo("There are no songs to add to your queue :(")
     }

--- a/components/results/result-list/result-list.spec.tsx
+++ b/components/results/result-list/result-list.spec.tsx
@@ -13,6 +13,7 @@ const mockTracks: Track[] = [
         imageLink: "",
         id: "1",
         uri: "",
+        explicit: true,
     },
     {
         previewUrl: "",
@@ -21,6 +22,7 @@ const mockTracks: Track[] = [
         imageLink: "",
         id: "2",
         uri: "",
+        explicit: true,
     },
     {
         previewUrl: "",
@@ -29,6 +31,7 @@ const mockTracks: Track[] = [
         imageLink: "",
         id: "3",
         uri: "",
+        explicit: false,
     },
 ]
 

--- a/components/results/results.spec.tsx
+++ b/components/results/results.spec.tsx
@@ -25,6 +25,7 @@ const mockTracks: Track[] = [
         imageLink: "",
         id: "1",
         uri: "",
+        explicit: false,
     },
     {
         previewUrl: "",
@@ -33,6 +34,7 @@ const mockTracks: Track[] = [
         imageLink: "",
         id: "2",
         uri: "",
+        explicit: true,
     },
 ]
 
@@ -339,6 +341,7 @@ describe("<Results />", () => {
 
             return promise().then((res: any) => {
                 res.find("#play-queue-btn").at(1).simulate("click")
+                res.find("#tooltip-next-btn").at(1).simulate("click")
                 expect(mockAddToQueue.mock.calls.length).to.be.eql(1)
             })
         })

--- a/components/results/results.tsx
+++ b/components/results/results.tsx
@@ -168,20 +168,20 @@ export const Results: FunctionComponent<ResultsProps> = (props) => {
                             id="play-queue-btn"
                             text="add to queue"
                             icon={<Queue width="26px" height="26px" />}
-                            onClick={async () => {
-                                await addToQueue(state.tracks)
-                            }}
                             tooltip={{
                                 text:
                                     userProduct === "premium"
-                                        ? `click here to add the above ${Mood[
+                                        ? `click continue to add the selected ${Mood[
                                               mood
                                           ].toLowerCase()} songs to your queue!`
                                         : "unfortunately, this feature is limited to spotify premium users only :(",
                                 id: "queue-tooltip",
                                 active: true,
-                                headerText:
-                                    "SPOTIFY BETA FEATURE WARNING: adding to queue might not fully work every time, so please try again if you encounter any problems!",
+                                warning: {
+                                    handleClick: async () => await addToQueue(state.tracks),
+                                    text:
+                                        "this might not fully work every time, so please try again if you encounter any problems!",
+                                },
                             }}
                         />
                         <Button

--- a/components/results/results.tsx
+++ b/components/results/results.tsx
@@ -169,9 +169,7 @@ export const Results: FunctionComponent<ResultsProps> = (props) => {
                             text="add to queue"
                             icon={<Queue width="26px" height="26px" />}
                             onClick={async () => {
-                                const result = await addToQueue(state.tracks)
-                                console.log(result)
-                                if (result) resetForm()
+                                await addToQueue(state.tracks)
                             }}
                             tooltip={{
                                 text:
@@ -182,11 +180,12 @@ export const Results: FunctionComponent<ResultsProps> = (props) => {
                                         : "unfortunately, this feature is limited to spotify premium users only :(",
                                 id: "queue-tooltip",
                                 active: true,
+                                headerText:
+                                    "SPOTIFY BETA FEATURE WARNING: adding to queue might not fully work every time, so please try again if you encounter any problems!",
                             }}
                         />
                         <Button
                             id="reset-btn"
-                            title="start over to begin a new moodqueue!"
                             icon={<Back width="26px" height="26px" />}
                             text="start over"
                             onClick={resetForm}
@@ -221,16 +220,18 @@ export const Results: FunctionComponent<ResultsProps> = (props) => {
             {showQueueWarningModal && !showPlaylistWarningModal && (
                 <Confirmation
                     id="queue-confirm"
-                    descText={`pressing the button below will add the ${tracks.length} ${Mood[
+                    descText={`pressing the button below will add the selected ${
+                        tracks.length
+                    } ${Mood[
                         mood
                     ].toLowerCase()} songs to your queue only if you have your spotify open and playing`}
-                    headerText="queue"
+                    headerText="queue (beta)"
                     btnText="add to queue"
+                    warningText="SPOTIFY BETA FEATURE WARNING: adding to queue might not fully work every time, so please try again if you encounter any problems!"
                     close={() => setShowQueueWarningModal(false)}
                     handleConfirmation={async () => {
-                        const result = await addToQueue(state.tracks)
+                        await addToQueue(state.tracks)
                         setShowQueueWarningModal(false)
-                        if (result) resetForm()
                     }}
                 />
             )}

--- a/components/results/results.tsx
+++ b/components/results/results.tsx
@@ -225,9 +225,13 @@ export const Results: FunctionComponent<ResultsProps> = (props) => {
                     } ${Mood[
                         mood
                     ].toLowerCase()} songs to your queue only if you have your spotify open and playing`}
-                    headerText="queue (beta)"
+                    headerText="queue"
                     btnText="add to queue"
-                    warningText="SPOTIFY BETA FEATURE WARNING: adding to queue might not fully work every time, so please try again if you encounter any problems!"
+                    warning={{
+                        text:
+                            "adding to queue might not fully work every time since it's a spotify beta feature, so please try again if you encounter any problems!",
+                        btnText: "BETA WARNING",
+                    }}
                     close={() => setShowQueueWarningModal(false)}
                     handleConfirmation={async () => {
                         await addToQueue(state.tracks)

--- a/components/results/results.tsx
+++ b/components/results/results.tsx
@@ -230,7 +230,6 @@ export const Results: FunctionComponent<ResultsProps> = (props) => {
                     warning={{
                         text:
                             "adding to queue might not fully work every time since it's a spotify beta feature, so please try again if you encounter any problems!",
-                        btnText: "BETA WARNING",
                     }}
                     close={() => setShowQueueWarningModal(false)}
                     handleConfirmation={async () => {

--- a/ui/button/Button.spec.tsx
+++ b/ui/button/Button.spec.tsx
@@ -23,7 +23,7 @@ describe("<Button />", () => {
         render(
             testComponent({
                 text: "hi",
-                tooltip: { text: "hello", id: "tooltip-id" },
+                tooltip: { text: "hello", id: "tooltip-id", active: true },
             })
         )
     })
@@ -33,7 +33,7 @@ describe("<Button />", () => {
             testComponent({
                 text: "hi",
                 small: true,
-                tooltip: { text: "hello", id: "small-tooltip-id" },
+                tooltip: { text: "hello", id: "small-tooltip-id", active: true },
             })
         )
     })

--- a/ui/button/Button.stories.tsx
+++ b/ui/button/Button.stories.tsx
@@ -10,7 +10,9 @@ export default { title: "Button" }
 export const largePrimary = () => withGrommet(<Button text="Hello, World!" />)
 
 export const largePrimaryTooltip = () =>
-    withGrommet(<Button text="Hello, World!" tooltip={{ text: "Hey", id: "tooltip-id" }} />)
+    withGrommet(
+        <Button text="Hello, World!" tooltip={{ text: "Hey", id: "tooltip-id", active: true }} />
+    )
 
 export const largePrimaryIcon = () => withGrommet(<Button text="Login" icon={<Spotify />} />)
 
@@ -25,7 +27,7 @@ export const smallSecondaryTooltip = () =>
     withGrommet(
         <Button
             text="Hello, World!"
-            tooltip={{ text: "I'm small", id: "small-tooltip-id" }}
+            tooltip={{ text: "I'm small", id: "small-tooltip-id", active: true }}
             small
             secondary
         />

--- a/ui/button/Button.styles.ts
+++ b/ui/button/Button.styles.ts
@@ -5,10 +5,38 @@ export const PrimaryButton = styled(GrommetButton)`
     border-radius: 30px;
     border: none;
     align-self: center;
+    padding-left: 32px;
+    padding-right: 32px;
+    padding-top: 10px;
+    padding-bottom: 10px;
+    font-weight: bold;
+    font-size: 22px;
 `
 
 export const SecondaryButton = styled(GrommetButton)`
     border-radius: 30px;
     border: none;
     align-self: center;
+    padding-left: 32px;
+    padding-right: 32px;
+    padding-top: 10px;
+    padding-bottom: 10px;
+    font-weight: bold;
+    font-size: 22px;
+`
+
+export const PrimaryButtonSmall = styled(PrimaryButton)`
+    padding-left: 20px;
+    padding-right: 20px;
+    padding-top: 6px;
+    padding-bottom: 6px;
+    font-size: 15px;
+`
+
+export const SecondaryButtonSmall = styled(SecondaryButton)`
+    padding-left: 20px;
+    padding-right: 20px;
+    padding-top: 6px;
+    padding-bottom: 6px;
+    font-size: 15px;
 `

--- a/ui/button/Button.tsx
+++ b/ui/button/Button.tsx
@@ -1,6 +1,11 @@
 import React from "react"
 import { motion } from "framer-motion"
-import { PrimaryButton, SecondaryButton } from "./Button.styles"
+import {
+    PrimaryButton,
+    PrimaryButtonSmall,
+    SecondaryButton,
+    SecondaryButtonSmall,
+} from "./Button.styles"
 import { Tooltip } from "./Tooltip"
 
 interface ButtonProps {
@@ -40,19 +45,19 @@ export const Button: React.FunctionComponent<ButtonProps> = (props) => {
         if (!tooltip) {
             return (
                 <motion.div whileHover={{ scale: 1.1 }} whileTap={{ scale: 0.9 }}>
-                    <SecondaryButton
+                    <SecondaryButtonSmall
                         id={id}
                         icon={icon}
                         onClick={onClick}
                         disabled={disabled}
                         hoverIndicator={hover}
-                        title={title}
                         primary={fill === undefined ? true : fill}
                         label={text}
                         margin={margin}
-                        color={color === undefined ? "accent-3" : color}
+                        plain
                         focusIndicator={false}
-                        size="small"
+                        color={color === undefined ? "accent-3" : color}
+                        style={{ padding: text === undefined ? 12 : undefined }}
                     />
                 </motion.div>
             )
@@ -60,19 +65,19 @@ export const Button: React.FunctionComponent<ButtonProps> = (props) => {
         return (
             <Tooltip tooltip={tooltip}>
                 <motion.div whileHover={{ scale: 1.1 }} whileTap={{ scale: 0.9 }}>
-                    <SecondaryButton
+                    <SecondaryButtonSmall
                         id={id}
                         icon={icon}
                         onClick={onClick}
                         disabled={disabled}
                         hoverIndicator={hover}
-                        title={title}
                         primary={fill === undefined ? true : fill}
                         label={text}
                         margin={margin}
-                        color={color === undefined ? "accent-3" : color}
+                        plain
                         focusIndicator={false}
-                        size="small"
+                        color={color === undefined ? "accent-3" : color}
+                        style={{ padding: text === undefined ? 12 : undefined }}
                     />
                 </motion.div>
             </Tooltip>
@@ -82,19 +87,19 @@ export const Button: React.FunctionComponent<ButtonProps> = (props) => {
         if (!tooltip) {
             return (
                 <motion.div whileHover={{ scale: 1.1 }} whileTap={{ scale: 0.9 }}>
-                    <PrimaryButton
+                    <PrimaryButtonSmall
                         id={id}
                         icon={icon}
                         onClick={onClick}
                         disabled={disabled}
                         hoverIndicator={hover}
-                        title={title}
                         color={color === undefined ? "accent-1" : color}
                         primary={fill === undefined ? true : fill}
                         label={text}
                         margin={margin}
+                        plain
                         focusIndicator={false}
-                        size="small"
+                        style={{ padding: text === undefined ? 12 : undefined }}
                     />
                 </motion.div>
             )
@@ -102,19 +107,19 @@ export const Button: React.FunctionComponent<ButtonProps> = (props) => {
         return (
             <Tooltip tooltip={tooltip}>
                 <motion.div whileHover={{ scale: 1.1 }} whileTap={{ scale: 0.9 }}>
-                    <PrimaryButton
+                    <PrimaryButtonSmall
                         id={id}
                         icon={icon}
                         onClick={onClick}
                         disabled={disabled}
                         hoverIndicator={hover}
-                        title={title}
                         color={color === undefined ? "accent-1" : color}
                         primary={fill === undefined ? true : fill}
                         label={text}
                         margin={margin}
+                        plain
                         focusIndicator={false}
-                        size="small"
+                        style={{ padding: text === undefined ? 12 : undefined }}
                     />
                 </motion.div>
             </Tooltip>
@@ -130,13 +135,14 @@ export const Button: React.FunctionComponent<ButtonProps> = (props) => {
                         label={text}
                         onClick={onClick}
                         disabled={disabled}
-                        size="large"
                         hoverIndicator={hover}
                         title={title}
                         color={color === undefined ? "accent-3" : color}
                         primary={fill === undefined ? true : fill}
                         margin={margin}
+                        plain
                         focusIndicator={false}
+                        style={{ padding: text === undefined ? 12 : undefined }}
                     />
                 </motion.div>
             )
@@ -150,13 +156,13 @@ export const Button: React.FunctionComponent<ButtonProps> = (props) => {
                         label={text}
                         onClick={onClick}
                         disabled={disabled}
-                        size="large"
                         hoverIndicator={hover}
-                        title={title}
                         color={color === undefined ? "accent-3" : color}
                         primary={fill === undefined ? true : fill}
                         margin={margin}
+                        plain
                         focusIndicator={false}
+                        style={{ padding: text === undefined ? 12 : undefined }}
                     />
                 </motion.div>
             </Tooltip>
@@ -171,13 +177,14 @@ export const Button: React.FunctionComponent<ButtonProps> = (props) => {
                         label={text}
                         onClick={onClick}
                         disabled={disabled}
-                        size="large"
                         hoverIndicator={hover}
                         title={title}
                         color={color === undefined ? "accent-1" : color}
                         primary={fill === undefined ? true : fill}
                         margin={margin}
+                        plain
                         focusIndicator={false}
+                        style={{ padding: text === undefined ? 12 : undefined }}
                     />
                 </motion.div>
             )
@@ -191,13 +198,13 @@ export const Button: React.FunctionComponent<ButtonProps> = (props) => {
                         label={text}
                         onClick={onClick}
                         disabled={disabled}
-                        size="large"
                         hoverIndicator={hover}
-                        title={title}
                         color={color === undefined ? "accent-1" : color}
                         primary={fill === undefined ? true : fill}
                         margin={margin}
+                        plain
                         focusIndicator={false}
+                        style={{ padding: text === undefined ? 12 : undefined }}
                     />
                 </motion.div>
             </Tooltip>

--- a/ui/button/Tooltip.tsx
+++ b/ui/button/Tooltip.tsx
@@ -1,7 +1,9 @@
 import { Box } from "grommet"
+import { Alert, FormClose, FormNextLink, FormPreviousLink, Hide } from "grommet-icons"
 import React from "react"
 import ReactTooltip from "react-tooltip"
 import { Description } from "../description/Description"
+import { Button } from "./Button"
 
 interface TooltipProps {
     tooltip: any
@@ -10,27 +12,76 @@ interface TooltipProps {
 
 export const Tooltip: React.FunctionComponent<TooltipProps> = (props) => {
     const { tooltip, children } = props
+    const [showWarning, setShowWarning] = React.useState(false)
 
     if (tooltip.active) {
         return (
             <Box align="center" id="tooltip-btn">
-                <a data-for={tooltip.id} data-tip>
+                <a
+                    data-for={tooltip.id}
+                    data-tip
+                    data-event={tooltip.warning ? "click" : undefined}
+                >
                     {children}
                 </a>
-                <ReactTooltip id={tooltip.id} backgroundColor="#D5DBDB" textColor="#2E4053">
+                <ReactTooltip
+                    id={tooltip.id}
+                    backgroundColor="#D5DBDB"
+                    textColor="#2E4053"
+                    clickable={tooltip.warning ? true : false}
+                    effect="solid"
+                    globalEventOff={tooltip.warning ? "click" : undefined}
+                >
                     <Box
-                        width={{ max: tooltip.headerText ? "medium" : "small" }}
+                        width={{ max: tooltip.warning ? "medium" : "small" }}
                         align="center"
                         gap="small"
+                        onClick={(e) => e.stopPropagation()}
+                        focusIndicator={false}
+                        style={{ outline: "none", cursor: "default" }}
                     >
-                        {tooltip.headerText && (
-                            <Description
-                                text={tooltip.headerText}
-                                textAlign="center"
-                                weight="bold"
-                            />
+                        {tooltip.warning ? (
+                            <Box align="center" gap="small" id="tooltip-warning">
+                                {showWarning ? (
+                                    <Box align="center" gap="small">
+                                        <Description
+                                            textAlign="center"
+                                            text={tooltip.warning.text}
+                                            size="medium"
+                                            //weight="bold"
+                                        />
+                                        <Button
+                                            icon={<Hide />}
+                                            color="#85C1E9"
+                                            small
+                                            onClick={() => setShowWarning(false)}
+                                            text="hide warning"
+                                        />
+                                    </Box>
+                                ) : (
+                                    <Box align="center" gap="small">
+                                        <Description text={tooltip.text} textAlign="center" />
+                                        <Box direction="row" align="center" gap="medium">
+                                            <Button
+                                                icon={<Alert />}
+                                                color="#F9E79F"
+                                                small
+                                                onClick={() => setShowWarning(true)}
+                                                text="show warning"
+                                            />
+                                            <Button
+                                                icon={<FormNextLink />}
+                                                onClick={tooltip.warning.handleClick}
+                                                small
+                                                text="continue"
+                                            />
+                                        </Box>
+                                    </Box>
+                                )}
+                            </Box>
+                        ) : (
+                            <Description text={tooltip.text} textAlign="center" />
                         )}
-                        <Description text={tooltip.text} textAlign="center" />
                     </Box>
                 </ReactTooltip>
             </Box>

--- a/ui/button/Tooltip.tsx
+++ b/ui/button/Tooltip.tsx
@@ -63,6 +63,7 @@ export const Tooltip: React.FunctionComponent<TooltipProps> = (props) => {
                                         <Description text={tooltip.text} textAlign="center" />
                                         <Box direction="row" align="center" gap="medium">
                                             <Button
+                                                id="tooltip-warning-btn"
                                                 icon={<Alert />}
                                                 color="#F9E79F"
                                                 small
@@ -70,6 +71,7 @@ export const Tooltip: React.FunctionComponent<TooltipProps> = (props) => {
                                                 text="show warning"
                                             />
                                             <Button
+                                                id="tooltip-next-btn"
                                                 icon={<FormNextLink />}
                                                 onClick={tooltip.warning.handleClick}
                                                 small

--- a/ui/button/Tooltip.tsx
+++ b/ui/button/Tooltip.tsx
@@ -17,8 +17,19 @@ export const Tooltip: React.FunctionComponent<TooltipProps> = (props) => {
                 <a data-for={tooltip.id} data-tip>
                     {children}
                 </a>
-                <ReactTooltip id={tooltip.id}>
-                    <Box width={{ max: "small" }} align="center">
+                <ReactTooltip id={tooltip.id} backgroundColor="#D5DBDB" textColor="#2E4053">
+                    <Box
+                        width={{ max: tooltip.headerText ? "medium" : "small" }}
+                        align="center"
+                        gap="small"
+                    >
+                        {tooltip.headerText && (
+                            <Description
+                                text={tooltip.headerText}
+                                textAlign="center"
+                                weight="bold"
+                            />
+                        )}
                         <Description text={tooltip.text} textAlign="center" />
                     </Box>
                 </ReactTooltip>

--- a/ui/confirmation/Confirmation.tsx
+++ b/ui/confirmation/Confirmation.tsx
@@ -1,5 +1,6 @@
 import { motion } from "framer-motion"
 import { Layer, Box } from "grommet"
+import { Alert } from "grommet-icons"
 import React from "react"
 import { trackDetailsVariants } from "../../components/animations/motion"
 import { Button } from "../button/Button"
@@ -13,7 +14,7 @@ interface ConfirmationProps {
     descText: string
     headerText: string
     id: any
-    warningText?: string
+    warning?: any
 }
 
 export const Confirmation: React.FunctionComponent<ConfirmationProps> = (props) => {
@@ -25,9 +26,10 @@ export const Confirmation: React.FunctionComponent<ConfirmationProps> = (props) 
         headerText,
         secondary,
         id,
-        warningText,
+        warning,
     } = props
     const [isOpen, setIsOpen] = React.useState(true)
+    const [showWarning, setShowWarning] = React.useState(false)
 
     return (
         <Layer
@@ -68,14 +70,6 @@ export const Confirmation: React.FunctionComponent<ConfirmationProps> = (props) 
                 >
                     <Description header text={headerText} textAlign="center" size="small" />
                     <Description textAlign="center" text={descText} size="small" />
-                    {warningText && (
-                        <Description
-                            textAlign="center"
-                            text={warningText}
-                            size="small"
-                            weight="bold"
-                        />
-                    )}
                     <Button
                         small
                         onClick={() => {
@@ -87,6 +81,31 @@ export const Confirmation: React.FunctionComponent<ConfirmationProps> = (props) 
                         text={btnText}
                         secondary={secondary === undefined ? false : secondary}
                     />
+                    {warning && (
+                        <Box align="center">
+                            <Button
+                                text={warning.btnText}
+                                icon={<Alert />}
+                                color="#E6B0AA"
+                                small
+                                onClick={() => setShowWarning(!showWarning)}
+                            />
+                            {showWarning && (
+                                <Box
+                                    round
+                                    background={{ color: "light-2", opacity: 0.3 }}
+                                    margin={{ top: "small" }}
+                                    pad="xsmall"
+                                >
+                                    <Description
+                                        textAlign="center"
+                                        text={warning.text}
+                                        size="small"
+                                    />
+                                </Box>
+                            )}
+                        </Box>
+                    )}
                 </Box>
             </motion.div>
         </Layer>

--- a/ui/confirmation/Confirmation.tsx
+++ b/ui/confirmation/Confirmation.tsx
@@ -30,7 +30,7 @@ export const Confirmation: React.FunctionComponent<ConfirmationProps> = (props) 
     } = props
     const [isOpen, setIsOpen] = React.useState(true)
     const [showWarning, setShowWarning] = React.useState(false)
-    const warningBtnText = showWarning ? "HIDE " + warning.btnText : "SHOW " + warning.btnText
+    const warningBtnText = (showWarning ? "hide " : "show ") + "warning"
 
     return (
         <Layer

--- a/ui/confirmation/Confirmation.tsx
+++ b/ui/confirmation/Confirmation.tsx
@@ -30,6 +30,7 @@ export const Confirmation: React.FunctionComponent<ConfirmationProps> = (props) 
     } = props
     const [isOpen, setIsOpen] = React.useState(true)
     const [showWarning, setShowWarning] = React.useState(false)
+    const warningBtnText = showWarning ? "HIDE " + warning.btnText : "SHOW " + warning.btnText
 
     return (
         <Layer
@@ -84,7 +85,7 @@ export const Confirmation: React.FunctionComponent<ConfirmationProps> = (props) 
                     {warning && (
                         <Box align="center">
                             <Button
-                                text={warning.btnText}
+                                text={warningBtnText}
                                 icon={<Alert />}
                                 color="#E6B0AA"
                                 small
@@ -101,6 +102,7 @@ export const Confirmation: React.FunctionComponent<ConfirmationProps> = (props) 
                                         textAlign="center"
                                         text={warning.text}
                                         size="small"
+                                        weight="bold"
                                     />
                                 </Box>
                             )}

--- a/ui/confirmation/Confirmation.tsx
+++ b/ui/confirmation/Confirmation.tsx
@@ -13,10 +13,20 @@ interface ConfirmationProps {
     descText: string
     headerText: string
     id: any
+    warningText?: string
 }
 
 export const Confirmation: React.FunctionComponent<ConfirmationProps> = (props) => {
-    const { close, btnText, handleConfirmation, descText, headerText, secondary, id } = props
+    const {
+        close,
+        btnText,
+        handleConfirmation,
+        descText,
+        headerText,
+        secondary,
+        id,
+        warningText,
+    } = props
     const [isOpen, setIsOpen] = React.useState(true)
 
     return (
@@ -58,6 +68,14 @@ export const Confirmation: React.FunctionComponent<ConfirmationProps> = (props) 
                 >
                     <Description header text={headerText} textAlign="center" size="small" />
                     <Description textAlign="center" text={descText} size="small" />
+                    {warningText && (
+                        <Description
+                            textAlign="center"
+                            text={warningText}
+                            size="small"
+                            weight="bold"
+                        />
+                    )}
                     <Button
                         small
                         onClick={() => {


### PR DESCRIPTION
i added a beta warning button to both web and mobile and slightly tweaked the UI for buttons and tooltips.

for web, i added some buttons to the add-to-queue tooltip so that users can either choose to continue and add songs or check out the warning and read that. 

for mobile, i added a show warning button to the confirmation component that's just a button that hides some content and shows it on a tap.

i also wanted to get rid of the ugle focus indicator that is on each button after you click it. the only way i could do that is to remove all padding and outlines that grommet adds in automatically. so, i had to add the padding back in with styled-components.

also also changed the color of the tooltips from black to soft white to fit more with the moodqueue vibe.